### PR TITLE
support absolute path CLI options by using path.resolve

### DIFF
--- a/src/cli/cli-command/analyze/analyze-cli-command.ts
+++ b/src/cli/cli-command/analyze/analyze-cli-command.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, writeFileSync } from "fs";
-import { extname, join } from "path";
+import { extname, resolve } from "path";
 import { Program, SourceFile } from "typescript";
 import { AnalyzeComponentsResult } from "../../../analyze/analyze-components";
 import { analyzeGlobs, AnalyzeGlobsContext } from "../../analyze-globs";
@@ -88,7 +88,7 @@ Options:
 					if (definition == null) return;
 
 					// The name of the file becomes the tagName of the first component definition in the file.
-					const path = join(process.cwd(), dirPath, definition.tagName) + extName;
+					const path = resolve(process.cwd(), dirPath, definition.tagName) + extName;
 					const transformed = this.transformResults(result, program, config);
 					writeFileSync(path, transformed);
 				}
@@ -117,7 +117,7 @@ Options:
 			const transformed = this.transformResults(results, program, config);
 
 			// Write the transformed the results to the file
-			const path = join(process.cwd(), config.outFile);
+			const path = resolve(process.cwd(), config.outFile);
 			writeFileSync(path, transformed);
 		}
 


### PR DESCRIPTION
Hello,

This updates the CLI to support providing options with absolute paths.  The context is that I'm scripting WCA and would like to use absolute paths for CLI options.  For instance:

```
wca analyze my-element.js --format json --outDir=$HOME/projects/my-elements/.tmp
```

But this doesn't work currently due to `path.join` not supporting absolute pathed arguments.  The result of the above command is trying to write the file to a path such as:

```
$HOME/projects/my-elements/$HOME/projects/my-elements/.tmp
```

I changed the code to use `path.resolve`, which works just like `path.join` but will honor absolute paths.

Tests are passing just fine.  Let me know if you'd like specific tests for this feature.  I didn't see any CLI-oriented tests or I would have added some right away.