### PR TITLE
bugfix: check custom element definitions for correct object

### DIFF
--- a/src/analyze/flavors/custom-element/visit-component-definitions.ts
+++ b/src/analyze/flavors/custom-element/visit-component-definitions.ts
@@ -14,7 +14,15 @@ export function visitComponentDefinitions(node: Node, context: VisitComponentDef
 	// customElements.define("my-element", MyElement)
 	if (ts.isCallExpression(node)) {
 		if (ts.isPropertyAccessExpression(node.expression)) {
-			if (node.expression.name != null && ts.isIdentifier(node.expression.name)) {
+			const leftExpression = node.expression.expression;
+			if (
+				((ts.isIdentifier(leftExpression) && leftExpression.escapedText === "customElements") ||
+					(ts.isPropertyAccessExpression(leftExpression) &&
+						ts.isIdentifier(leftExpression.expression) &&
+						leftExpression.expression.escapedText === "window")) &&
+				node.expression.name != null &&
+				ts.isIdentifier(node.expression.name)
+			) {
 				// define("my-element", MyElement)
 				if (node.expression.name.escapedText === "define") {
 					const [tagNameNode, identifierNode] = node.arguments;

--- a/src/analyze/flavors/custom-element/visit-component-definitions.ts
+++ b/src/analyze/flavors/custom-element/visit-component-definitions.ts
@@ -14,12 +14,17 @@ export function visitComponentDefinitions(node: Node, context: VisitComponentDef
 	// customElements.define("my-element", MyElement)
 	if (ts.isCallExpression(node)) {
 		if (ts.isPropertyAccessExpression(node.expression)) {
-			const leftExpression = node.expression.expression;
+			let leftExpression = node.expression.expression;
 			if (
-				((ts.isIdentifier(leftExpression) && leftExpression.escapedText === "customElements") ||
-					(ts.isPropertyAccessExpression(leftExpression) &&
-						ts.isIdentifier(leftExpression.expression) &&
-						leftExpression.expression.escapedText === "window")) &&
+				ts.isPropertyAccessExpression(leftExpression) &&
+				ts.isIdentifier(leftExpression.expression) &&
+				leftExpression.expression.escapedText === "window"
+			) {
+				leftExpression = leftExpression.name;
+			}
+			if (
+				ts.isIdentifier(leftExpression) &&
+				leftExpression.escapedText === "customElements" &&
 				node.expression.name != null &&
 				ts.isIdentifier(node.expression.name)
 			) {

--- a/test/flavors/custom-element/ctor-test.ts
+++ b/test/flavors/custom-element/ctor-test.ts
@@ -27,7 +27,7 @@ test("Property assignments in the constructor are picked up", t => {
 			}
 		}
 		
-		customElement.define("my-element", MyElement);
+		customElements.define("my-element", MyElement);
 	 `);
 
 	const {
@@ -75,7 +75,7 @@ test("Property assignments in the constructor are correctly merged", t => {
 			}
 		}
 		
-		customElement.define("my-element", MyElement);
+		customElements.define("my-element", MyElement);
 	 `);
 
 	const {
@@ -101,7 +101,7 @@ test("Property assignments in the constructor don't overwrite Typescript modifie
 			}
 		}
 		
-		customElement.define("my-element", MyElement);
+		customElements.define("my-element", MyElement);
 	 `);
 
 	const {

--- a/test/flavors/custom-element/mixin-test.ts
+++ b/test/flavors/custom-element/mixin-test.ts
@@ -18,7 +18,7 @@ test("Handles simple mixin", t => {
 			}
 		}
 		
-		customElement.define("my-element", MyElement);
+		customElements.define("my-element", MyElement);
 	 `);
 
 	const {
@@ -53,7 +53,7 @@ test("Handles 2 levels of mixins", t => {
 			}
 		}
 		
-		customElement.define("my-element", MyElement);
+		customElements.define("my-element", MyElement);
 	 `);
 
 	const {
@@ -140,7 +140,7 @@ test("Handles nested mixin extends", t => {
 			}
 		}
 		
-		customElement.define("my-element", MyElement);
+		customElements.define("my-element", MyElement);
 	 `);
 
 	const {


### PR DESCRIPTION
hello

this is to reduce the greediness of your `define` visitor as it currently picks up a _lot_ of false positives in codebases where other classes have a `define` method.

i added a check to ensure it the left hand expression is `customElements` or `window.customElements`.

i haven't yet figured out your test workflow but will add a test case once i have

ah and a few of your tests had `customElement.define` which seemed wrong.. LMK if it was on purpose.