### PR TITLE
Improve handling of @customElement(variable)

### DIFF
--- a/src/analyze/flavors/lit-element/discover-definitions.ts
+++ b/src/analyze/flavors/lit-element/discover-definitions.ts
@@ -27,7 +27,7 @@ export function discoverDefinitions(node: Node, context: AnalyzerVisitContext): 
 				if (decoratorIdentifierName === "customElement") {
 					// Resolve the value of the first argument. This is the tag name.
 					const unresolvedTagNameNode = callExpression.arguments[0];
-					const resolvedTagNameNode = resolveNodeValue(unresolvedTagNameNode, { ts, checker });
+					const resolvedTagNameNode = resolveNodeValue(unresolvedTagNameNode, { ts, checker, strict: true });
 					const identifier = getNodeIdentifier(node, context);
 
 					if (resolvedTagNameNode != null && typeof resolvedTagNameNode.value === "string") {

--- a/test/flavors/lit-element/discover-test.ts
+++ b/test/flavors/lit-element/discover-test.ts
@@ -5,7 +5,7 @@ tsTest("LitElement: Discovers elements defined using @customElement decorator", 
 	const {
 		results: [result]
 	} = analyzeTextWithCurrentTsModule(`
-		@customElement("my-element")	
+		@customElement("my-element")
 		class MyElement extends HTMLElement {
 		}
 	 `);
@@ -14,4 +14,38 @@ tsTest("LitElement: Discovers elements defined using @customElement decorator", 
 
 	t.is(componentDefinitions.length, 1);
 	t.is(componentDefinitions[0].tagName, "my-element");
+});
+
+let testName = "LitElement: Discovers @customElement(stringConstant)";
+tsTest(testName, t => {
+	const {
+		results: [result]
+	} = analyzeTextWithCurrentTsModule(`
+		const str = 'string-constant';
+		@customElement(str)
+		class MyElement extends HTMLElement {
+		}
+	 `);
+
+	const { componentDefinitions } = result;
+
+	t.is(componentDefinitions.length, 1);
+	t.is(componentDefinitions[0].tagName, "string-constant");
+});
+
+testName = "LitElement: Doesn't discover @customElement(stringVariable)";
+tsTest(testName, t => {
+	const {
+		results: [result]
+	} = analyzeTextWithCurrentTsModule(`
+		function defineElem(str: string) {;
+			@customElement(str)
+			class MyElement extends HTMLElement {
+			}
+		}
+	 `);
+
+	const { componentDefinitions } = result;
+
+	t.is(componentDefinitions.length, 0);
 });


### PR DESCRIPTION
If resolveNodeValue is called on an identifier without a strict context, it will return the identifier's name as a the value, which isn't what we want when resolving a custom element tagname.