### PR TITLE
Prepare 2.0.0-next.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
 	"name": "web-component-analyzer",
-	"version": "1.2.0-next.0",
+	"version": "2.0.0-next.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"version": "1.2.0-next.0",
+			"version": "2.0.0-next.0",
 			"license": "MIT",
 			"dependencies": {
 				"fast-glob": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web-component-analyzer",
-	"version": "1.2.0-next.0",
+	"version": "2.0.0-next.0",
 	"description": "CLI that analyzes web components",
 	"main": "lib/cjs/api.js",
 	"module": "lib/esm/api.js",


### PR DESCRIPTION
Preparing a new release under the `@next` tag.

This just includes the upgrade to TypeScript 4.3, which might be a breaking change, so we might want to make this 2.0.0-next.0