### PR TITLE
Fix built-in property visibility bug cause by LwcFlavor

### DIFF
--- a/src/analyze/flavors/lwc/refine-feature.ts
+++ b/src/analyze/flavors/lwc/refine-feature.ts
@@ -42,9 +42,9 @@ function isLWCComponent(component: ComponentFeatureBase, context: AnalyzerVisitC
 	if (node) {
 		return !!getLwcComponent(node, context);
 	}
-	// How do we know that we are dealing with LWC components?
-	// Currently assume that it is always the case
-	return true;
+	// You can't assume that everything is a LWC component - that will cause huge
+	// problems with the refinement rules below that switch default visibility to protected!!
+	return false;
 }
 
 export const refineFeature: AnalyzerFlavor["refineFeature"] = {

--- a/test/flavors/custom-element/analyze-built-ins-test.ts
+++ b/test/flavors/custom-element/analyze-built-ins-test.ts
@@ -15,6 +15,7 @@ tsTest("analyzeSourceFile on lib.dom.ts returns correct result", t => {
 
 	const result = analyzeSourceFile(domLibSourceFile, {
 		program,
+		ts: tsModule,
 		config: {
 			features: ["event", "member", "slot", "csspart", "cssproperty"],
 			analyzeGlobalFeatures: false, // Don't analyze global features in lib.dom.d.ts

--- a/test/flavors/custom-element/analyze-built-ins-test.ts
+++ b/test/flavors/custom-element/analyze-built-ins-test.ts
@@ -31,7 +31,8 @@ tsTest("analyzeSourceFile on lib.dom.ts returns correct result", t => {
 	t.truthy(scriptDefinition);
 
 	// const properties = scriptDefinition?.declaration?.members.filter(m => m.kind === "property");
-	const srcProperty = scriptDefinition?.declaration?.members.find(m => m.kind === "property" && m.propName === "src");
+	const srcProperty = scriptDefinition!.declaration?.members.find(m => m.kind === "property" && m.propName === "src");
 
-	t.is(srcProperty?.visibility, "public");
+	t.truthy(srcProperty);
+	t.true(srcProperty!.visibility === undefined || srcProperty!.visibility === "public", `srcProperty!.visibility is "${srcProperty!.visibility}"`);
 });

--- a/test/flavors/custom-element/analyze-built-ins-test.ts
+++ b/test/flavors/custom-element/analyze-built-ins-test.ts
@@ -1,0 +1,37 @@
+import { join } from "path";
+import { analyzeSourceFile } from "../../../src/analyze/analyze-source-file";
+import { getCurrentTsModule, getCurrentTsModuleDirectory, tsTest } from "../../helpers/ts-test";
+
+tsTest("analyzeSourceFile on lib.dom.ts returns correct result", t => {
+	const tsModule = getCurrentTsModule();
+	const program = tsModule.createProgram([join(getCurrentTsModuleDirectory(), "lib.dom.d.ts")], {});
+
+	const endsWithLibDom = "lib.dom.d.ts";
+
+	const domLibSourceFile = program.getSourceFiles().find(sf => sf.fileName.endsWith(endsWithLibDom));
+	if (domLibSourceFile == null) {
+		throw new Error(`Couldn't find '${endsWithLibDom}'. Have you included the 'dom' lib in your tsconfig?`);
+	}
+
+	const result = analyzeSourceFile(domLibSourceFile, {
+		program,
+		config: {
+			features: ["event", "member", "slot", "csspart", "cssproperty"],
+			analyzeGlobalFeatures: false, // Don't analyze global features in lib.dom.d.ts
+			analyzeDefaultLib: true,
+			analyzeDependencies: true,
+			analyzeAllDeclarations: false,
+			excludedDeclarationNames: ["HTMLElement"]
+		}
+	});
+
+	t.truthy(result);
+
+	const scriptDefinition = result.componentDefinitions?.find(d => d.tagName === "script");
+	t.truthy(scriptDefinition);
+
+	// const properties = scriptDefinition?.declaration?.members.filter(m => m.kind === "property");
+	const srcProperty = scriptDefinition?.declaration?.members.find(m => m.kind === "property" && m.propName === "src");
+
+	t.is(srcProperty?.visibility, "public");
+});

--- a/test/flavors/custom-element/analyze-built-ins-test.ts
+++ b/test/flavors/custom-element/analyze-built-ins-test.ts
@@ -31,7 +31,6 @@ tsTest("analyzeSourceFile on lib.dom.ts returns correct result", t => {
 	const scriptDefinition = result.componentDefinitions?.find(d => d.tagName === "script");
 	t.truthy(scriptDefinition);
 
-	// const properties = scriptDefinition?.declaration?.members.filter(m => m.kind === "property");
 	const srcProperty = scriptDefinition!.declaration?.members.find(m => m.kind === "property" && m.propName === "src");
 
 	t.truthy(srcProperty);

--- a/test/flavors/lwc/member-test.ts
+++ b/test/flavors/lwc/member-test.ts
@@ -42,6 +42,48 @@ tsTest("LWC: Discovers properties from '@api'", t => {
 	);
 });
 
+tsTest("LWC: doesn't process non-LWC element'", t => {
+	const {
+		results: [result],
+		checker
+	} = analyzeTextWithCurrentTsModule({
+		fileName: "modules/custom/myElement/myElement.ts",
+		text: `
+		// This is defined as an interface to test a regression
+		interface MyElement extends HTMLElement {
+			myProp: string;
+		}
+		declare var MyElement: {
+			prototype: MyElement;
+			new(): MyElement;
+		};
+		interface HTMLElementTagNameMap {
+			'my-element': MyElement,
+		}
+	`
+	});
+
+	const { members = [] } = result.componentDefinitions[0]?.declaration || {};
+	assertHasMembers(
+		members,
+		[
+			{
+				kind: "property",
+				propName: "myProp",
+				default: undefined,
+				typeHint: undefined,
+				type: () => ({ kind: "STRING" }),
+				visibility: "public",
+				reflect: undefined,
+				deprecated: undefined,
+				required: undefined
+			}
+		],
+		t,
+		checker
+	);
+});
+
 tsTest("LWC: Discovers properties without @api'", t => {
 	const {
 		results: [result],


### PR DESCRIPTION
This was a rough one to figure out.

The way flavors work they all get a chance to work against a definition and potentially refine features. A bug in LwcFlavor caused it to do work again non-LWC definitions and part of its feature refinement is to default all class members to protected visibility. This refinement was running against all built-in definitions cause built-in public properties to be changed to protected. This was only caught by one security test in lit-analyzer because lit-analyzer filters out non-public fields before type-checking.