### PR TITLE
chore: upgrade typescript to 4.4.x

### DIFF
--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -5,6 +5,7 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "dev",
 			"version": "1.0.0",
 			"license": "ISC",
 			"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,12 +5,13 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "web-component-analyzer",
 			"version": "2.0.0-next.3",
 			"license": "MIT",
 			"dependencies": {
 				"fast-glob": "^3.2.2",
 				"ts-simple-type": "2.0.0-next.0",
-				"typescript": "~4.3.2",
+				"typescript": "^4.4.3",
 				"yargs": "^15.3.1"
 			},
 			"bin": {
@@ -258,9 +259,9 @@
 			}
 		},
 		"node_modules/@rollup/plugin-typescript": {
-			"version": "8.2.3",
-			"resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-8.2.3.tgz",
-			"integrity": "sha512-bSkd+DD3wP9OLU6lPet59B6jJF29/RlxHkbwvOVOcf1nk8eQYWw24HpldEdrPo/WG0QAPD7TqI7+2y5jtdqjww==",
+			"version": "8.2.5",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-8.2.5.tgz",
+			"integrity": "sha512-QL/LvDol/PAGB2O0S7/+q2HpSUNodpw7z6nGn9BfoVCPOZ0r4EALrojFU29Bkoi2Hr2jgTocTejJ5GGWZfOxbQ==",
 			"dev": true,
 			"dependencies": {
 				"@rollup/pluginutils": "^3.1.0",
@@ -4992,9 +4993,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.3.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-			"integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
+			"integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -5587,9 +5588,9 @@
 			}
 		},
 		"@rollup/plugin-typescript": {
-			"version": "8.2.3",
-			"resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-8.2.3.tgz",
-			"integrity": "sha512-bSkd+DD3wP9OLU6lPet59B6jJF29/RlxHkbwvOVOcf1nk8eQYWw24HpldEdrPo/WG0QAPD7TqI7+2y5jtdqjww==",
+			"version": "8.2.5",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-8.2.5.tgz",
+			"integrity": "sha512-QL/LvDol/PAGB2O0S7/+q2HpSUNodpw7z6nGn9BfoVCPOZ0r4EALrojFU29Bkoi2Hr2jgTocTejJ5GGWZfOxbQ==",
 			"dev": true,
 			"requires": {
 				"@rollup/pluginutils": "^3.1.0",
@@ -9098,9 +9099,9 @@
 			}
 		},
 		"typescript": {
-			"version": "4.3.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-			"integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA=="
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
+			"integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA=="
 		},
 		"typescript-3.5": {
 			"version": "npm:typescript@3.5.3",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
 	"dependencies": {
 		"fast-glob": "^3.2.2",
 		"ts-simple-type": "2.0.0-next.0",
-		"typescript": "~4.3.2",
+		"typescript": "^4.4.3",
 		"yargs": "^15.3.1"
 	},
 	"devDependencies": {

--- a/src/cli/util/cli-error.ts
+++ b/src/cli/util/cli-error.ts
@@ -15,6 +15,6 @@ export function makeCliError(message: string): Error {
  * Returns if an error is of kind "CLIError"
  * @param error
  */
-export function isCliError(error: Error): boolean {
-	return error.name === ERROR_NAME;
+export function isCliError(error: unknown): error is Error {
+	return error instanceof Error && error.name === ERROR_NAME;
 }

--- a/src/cli/util/file-util.ts
+++ b/src/cli/util/file-util.ts
@@ -4,6 +4,6 @@ export function ensureDirSync(dir: string): void {
 	try {
 		mkdirSync(dir, { recursive: true });
 	} catch (err) {
-		if (err.code !== "EEXIST") throw err;
+		if ((err as Error & { code: string }).code !== "EEXIST") throw err;
 	}
 }


### PR DESCRIPTION
This updates typescript from 4.3 to 4.4.

4.4 introduces new behaviour where catch blocks are given an `unknown` rather than `Error`. do we want to change the logic like i've done here or just switch that behaviour off?

cc @justinfagnani @rictic 