### PR TITLE
fix: resolve literal type nodes

### DIFF
--- a/src/analyze/util/resolve-node-value.ts
+++ b/src/analyze/util/resolve-node-value.ts
@@ -130,6 +130,18 @@ export function resolveNodeValue(node: Node | undefined, context: Context): { va
 		};
 	}
 
+	if (ts.isTypeAliasDeclaration(node)) {
+		return resolveNodeValue(node.type, { ...context, depth });
+	}
+
+	if (ts.isLiteralTypeNode(node)) {
+		return resolveNodeValue(node.literal, { ...context, depth });
+	}
+
+	if (ts.isTypeReferenceNode(node)) {
+		return resolveNodeValue(node.typeName, { ...context, depth });
+	}
+
 	return undefined;
 }
 

--- a/test/util/resolve-node-value.spec.ts
+++ b/test/util/resolve-node-value.spec.ts
@@ -35,3 +35,20 @@ const g = a;
 		t.deepEqual(actualValue, expectedResult, `Resolved value for '${name.getText()}' is invalid`);
 	});
 });
+
+test("resolveNodeValue resolves type literals", t => {
+	const {
+		analyzedSourceFiles: [sourceFile],
+		program
+	} = analyzeText(`
+type StringLiteral = "popsicles";
+type AliasedLiteral = StringLiteral;
+	`);
+
+	const checker = program.getTypeChecker();
+
+	findChildren(sourceFile, ts.isTypeAliasDeclaration, ({ name, type }) => {
+		const actualValue = resolveNodeValue(type, { checker, ts })?.value;
+		t.is(actualValue, "popsicles", `Resolved value for '${name.getText()}' is invalid`);
+	});
+});


### PR DESCRIPTION
Fixes runem/lit-analyzer#205

Here you go @rictic. It already supports computed property resolution by the looks of it, but doesn't support resolving type references so this should solve that.