### PR TITLE
Add ignore of PolymerElement super class node on custom-element analysis

### DIFF
--- a/src/analyze/flavors/custom-element/exclude-node.ts
+++ b/src/analyze/flavors/custom-element/exclude-node.ts
@@ -1,5 +1,6 @@
 import { Node } from "typescript";
 import { AnalyzerVisitContext } from "../../analyzer-visit-context";
+import { getNodeName } from "../../util/ast-util";
 
 /**
  * Excludes nodes from "lib.dom.d.ts" if analyzeLibDom is false
@@ -9,6 +10,12 @@ import { AnalyzerVisitContext } from "../../analyzer-visit-context";
 export function excludeNode(node: Node, context: AnalyzerVisitContext): boolean | undefined {
 	if (context.config.analyzeDefaultLib) {
 		return undefined;
+	}
+
+	// Exclude polymer element related super classes
+	const declName = getNodeName(node, context);
+	if (declName === "PolymerElement") {
+		return true;
 	}
 
 	return isLibDom(node);


### PR DESCRIPTION
Analysis of Polymer custom components reports Polymer super class related properties and functions.

The pull request adds ignore of this super class to get only component defined properties and function like with Polymer provided tooling.

<details>
  <summary>Example of analyzed source</summary>

```js
import {PolymerElement, html} from '@polymer/polymer/polymer-element';

/**
 * @polymer
 * @customElement
 *
 * @fires test-event My super custom event
 */
export class PolymerTest2 extends PolymerElement {
  static get properties() {
    /**
     * @lends PolymerTest2.prototype
     */
    return {
      /**
       * Test plop property
       * @type {string}
       */
      testPlop: {
        type: String
      },

      /**
       * Test plopp property
       * @type {number}
       */
      testPlopp: {
        type: Number,
        value: 1
      }
    };
  }

  static get template() {
    // language=HTML
    return html`
      [[testPlop]] - [[testPlopp]]
    `;
  }
}

customElements.define('polymer-test2', PolymerTest2);
```
</details>

<details>
  <summary>Markdown result with pull request code</summary>

# polymer-test2

## Properties

| Property    | Attribute    | Type     | Default | Description         |
|-------------|--------------|----------|---------|---------------------|
| `testPlop`  | `test-plop`  | `string` |         | Test plop property  |
| `testPlopp` | `test-plopp` | `number` | 1       | Test plopp property |

## Events

| Event        | Description           |
|--------------|-----------------------|
| `test-event` | My super custom event |

</details>

<details>
  <summary>Markdown result without pull request code</summary>

# polymer-test2

**Mixins:** ElementMixin

## Properties

| Property                | Attribute    | Modifiers | Type                                             | Default | Description         |
|-------------------------|--------------|-----------|--------------------------------------------------|---------|---------------------|
| `$`                     |              |           | `{ [key: string]: Element; }`                    |         |                     |
| `PROPERTY_EFFECT_TYPES` |              | readonly  |                                                  |         |                     |
| `importPath`            |              |           | `string`                                         |         |                     |
| `root`                  |              |           | `HTMLElement \| StampedTemplate \| ShadowRoot \| null` |         |                     |
| `rootPath`              |              |           | `string`                                         |         |                     |
| `testPlop`              | `test-plop`  |           | `string`                                         |         | Test plop property  |
| `testPlopp`             | `test-plopp` |           | `number`                                         | 1       | Test plopp property |

## Methods

| Method                          | Type                                             | Description                                      |
|---------------------------------|--------------------------------------------------|--------------------------------------------------|
| `addPropertyEffect`             | `(property: string, type: string, effect?: object \| null \| undefined): void` | Ensures an accessor exists for the specified property, and adds<br />to a list of "property effects" that will run when the accessor for<br />the specified property is set.  Effects are grouped by "type", which<br />roughly corresponds to a phase in effect processing.  The effect<br />metadata should be in the following form:<br /><br />     {<br />       fn: effectFunction, // Reference to function to call to perform effect<br />       info: { ... }       // Effect metadata passed to function<br />       trigger: {          // Optional triggering metadata; if not provided<br />         name: string      // the property is treated as a wildcard<br />         structured: boolean<br />         wildcard: boolean<br />       }<br />     }<br /><br />Effects are called from `_propertiesChanged` in the following order by<br />type:<br /><br />1. COMPUTE<br />2. PROPAGATE<br />3. REFLECT<br />4. OBSERVE<br />5. NOTIFY<br /><br />Effect functions are called with the following signature:<br /><br />     effectFunction(inst, path, props, oldProps, info, hasPaths)<br /><br />**property**: Property that should trigger the effect<br />**type**: Effect type, from this.PROPERTY_EFFECT_TYPES<br />**effect**: Effect metadata object |
| `attributeNameForProperty`      | `(property: string): string`                     | Returns an attribute name that corresponds to the given property.<br />By default, converts camel to dash case, e.g. `fooBar` to `foo-bar`.<br /><br />**property**: Property to convert |
| `bindTemplate`                  | `(template: HTMLTemplateElement): TemplateInfo`  | Parses the provided template to ensure binding effects are created<br />for them, and then ensures property accessors are created for any<br />dependent properties in the template.  Binding effects for bound<br />templates are stored in a linked list on the instance so that<br />templates can be efficiently stamped and unstamped.<br /><br />**template**: Template containing binding<br />bindings |
| `createComputedProperty`        | `(property: string, expression: string, dynamicFn?: boolean \| object \| null \| undefined): void` | Creates a computed property whose value is set to the result of the<br />method described by the given `expression` each time one or more<br />arguments to the method changes.  The expression should be a string<br />in the form of a normal JavaScript function signature:<br />`'methodName(arg1, [..., argn])'`<br /><br />**property**: Name of computed property to set<br />**expression**: Method expression<br />**dynamicFn**: Boolean or object map indicating whether<br />method names should be included as a dependency to the effect. |
| `createMethodObserver`          | `(expression: string, dynamicFn?: boolean \| object \| null \| undefined): void` | Creates a multi-property "method observer" based on the provided<br />expression, which should be a string in the form of a normal JavaScript<br />function signature: `'methodName(arg1, [..., argn])'`.  Each argument<br />should correspond to a property or path in the context of this<br />prototype (or instance), or may be a literal string or number.<br /><br />**expression**: Method expression<br />**dynamicFn**: Boolean or object map indicating |
| `createNotifyingProperty`       | `(property: string): void`                       | Causes the setter for the given property to dispatch `<property>-changed`<br />events to notify of changes to the property.<br /><br />**property**: Property name |
| `createObservers`               | `(observers: object \| null, dynamicFns: object \| null): void` | Creates observers for the given `observers` array.<br />Leverages `PropertyEffects` to create observers.<br /><br />**observers**: Array of observer descriptors for<br />this class<br />**dynamicFns**: Object containing keys for any properties<br />that are functions and should trigger the effect when the function<br />reference is changed |
| `createProperties`              | `(props: object): void`                          | Override of PropertiesChanged createProperties to create accessors<br />and property effects for all of the properties.<br /><br />**props**: . |
| `createPropertiesForAttributes` | `(): void`                                       | Generates property accessors for all attributes in the standard<br />static `observedAttributes` array.<br /><br />Attribute names are mapped to property names using the `dash-case` to<br />`camelCase` convention |
| `createPropertyObserver`        | `(property: string, method: string \| ((p0: any, p1: any): any), dynamicFn?: boolean \| undefined) => void` | Creates a single-property observer for the given property.<br /><br />**property**: Property name<br />**method**: Function or name of observer method to call<br />**dynamicFn**: Whether the method name should be included as<br />a dependency to the effect. |
| `createReadOnlyProperty`        | `(property: string, protectedSetter?: boolean \| undefined): void` | Creates a read-only accessor for the given property.<br /><br />To set the property, use the protected `_setProperty` API.<br />To create a custom protected setter (e.g. `_setMyProp()` for<br />property `myProp`), pass `true` for `protectedSetter`.<br /><br />Note, if the property will have other property effects, this method<br />should be called first, before adding other effects.<br /><br />**property**: Property name<br />**protectedSetter**: Creates a custom protected setter<br />when `true`. |
| `createReflectedProperty`       | `(property: string): void`                       | Causes the setter for the given property to reflect the property value<br />to a (dash-cased) attribute of the same name.<br /><br />**property**: Property name |
| `finalize`                      | `(): void`                                       | Finalizes an element definition, including ensuring any super classes<br />are also finalized. This includes ensuring property<br />accessors exist on the element prototype. This method calls<br />`_finalizeClass` to finalize each constructor in the prototype chain. |
| `get`                           | `(path: string \| (string \| number)[], root?: object \| null \| undefined): any` | Convenience method for reading a value from a path.<br /><br />Note, if any part in the path is undefined, this method returns<br />`undefined` (this method does not throw when dereferencing undefined<br />paths).<br /><br />**path**: Path to the value<br />to read.  The path may be specified as a string (e.g. `foo.bar.baz`)<br />or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that<br />bracketed expressions are not supported; string-based path parts<br />*must* be separated by dots.  Note that when dereferencing array<br />indices, the index may be used as a dotted part directly<br />(e.g. `users.12.name` or `['users', 12, 'name']`).<br />**root**: Root object from which the path is evaluated. |
| `linkPaths`                     | `(to: string \| (string \| number)[], from: string \| (string \| number)[]): void` | Aliases one data path as another, such that path notifications from one<br />are routed to the other.<br /><br />**to**: Target path to link.<br />**from**: Source path to link. |
| `notifyPath`                    | `(path: string, value?: any): void`              | Notify that a path has changed.<br /><br />Example:<br /><br />     this.item.user.name = 'Bob';<br />     this.notifyPath('item.user.name');<br /><br />**path**: Path that should be notified.<br />**value**: Value at the path (optional). |
| `notifySplices`                 | `(path: string, splices: any[] \| null): void`   | Notify that an array has changed.<br /><br />Example:<br /><br />     this.items = [ {name: 'Jim'}, {name: 'Todd'}, {name: 'Bill'} ];<br />     ...<br />     this.items.splice(1, 1, {name: 'Sam'});<br />     this.items.push({name: 'Bob'});<br />     this.notifySplices('items', [<br />       { index: 1, removed: [{name: 'Todd'}], addedCount: 1,<br />         object: this.items, type: 'splice' },<br />       { index: 3, removed: [], addedCount: 1,<br />         object: this.items, type: 'splice'}<br />     ]);<br /><br />**path**: Path that should be notified.<br />**splices**: Array of splice records indicating ordered<br />changes that occurred to the array. Each record should have the<br />following fields:<br />* index: index at which the change occurred<br />* removed: array of items that were removed from this index<br />* addedCount: number of new items added at this index<br />* object: a reference to the array in question<br />* type: the string literal 'splice'<br /><br />Note that splice records _must_ be normalized such that they are<br />reported in index order (raw results from `Object.observe` are not<br />ordered and must be normalized/merged before notifying). |
| `pop`                           | `(path: string \| (string \| number)[]): any`    | Removes an item from the end of array at the path specified.<br /><br />The arguments after `path` and return value match that of<br />`Array.prototype.pop`.<br /><br />This method notifies other paths to the same array that a<br />splice occurred to the array.<br /><br />**path**: Path to array. |
| `push`                          | `(path: string \| (string \| number)[], ...items: any[]): number` | Adds items onto the end of the array at the path specified.<br /><br />The arguments after `path` and return value match that of<br />`Array.prototype.push`.<br /><br />This method notifies other paths to the same array that a<br />splice occurred to the array.<br /><br />**path**: Path to array.<br />**items**: Items to push onto array |
| `ready`                         | `(): void`                                       | Stamps the element template.                     |
| `resolveUrl`                    | `(url: string, base?: string \| undefined): string` | Rewrites a given URL relative to a base URL. The base URL defaults to<br />the original location of the document containing the `dom-module` for<br />this element. This method will return the same URL before and after<br />bundling.<br /><br />Note that this function performs no resolution for URLs that start<br />with `/` (absolute URLs) or `#` (hash identifiers).  For general purpose<br />URL resolution, use `window.URL`.<br /><br />**url**: URL to resolve.<br />**base**: Optional base URL to resolve against, defaults<br />to the element's `importPath` |
| `set`                           | `(path: string \| (string \| number)[], value: any, root?: object \| null \| undefined): void` | Convenience method for setting a value to a path and notifying any<br />elements bound to the same path.<br /><br />Note, if any part in the path except for the last is undefined,<br />this method does nothing (this method does not throw when<br />dereferencing undefined paths).<br /><br />**path**: Path to the value<br />to write.  The path may be specified as a string (e.g. `'foo.bar.baz'`)<br />or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that<br />bracketed expressions are not supported; string-based path parts<br />*must* be separated by dots.  Note that when dereferencing array<br />indices, the index may be used as a dotted part directly<br />(e.g. `'users.12.name'` or `['users', 12, 'name']`).<br />**value**: Value to set at the specified path.<br />**root**: Root object from which the path is evaluated.<br />When specified, no notification will occur. |
| `setProperties`                 | `(props: object \| null, setReadOnly?: boolean \| undefined): void` | Sets a bag of property changes to this instance, and<br />synchronously processes all effects of the properties as a batch.<br /><br />Property names must be simple properties, not paths.  Batched<br />path propagation is not supported.<br /><br />**props**: Bag of one or more key-value pairs whose key is<br />a property and value is the new value to set for that property.<br />**setReadOnly**: When true, any private values set in<br />`props` will be set. By default, `setProperties` will not set<br />`readOnly: true` root properties. |
| `shift`                         | `(path: string \| (string \| number)[]): any`    | Removes an item from the beginning of array at the path specified.<br /><br />The arguments after `path` and return value match that of<br />`Array.prototype.pop`.<br /><br />This method notifies other paths to the same array that a<br />splice occurred to the array.<br /><br />**path**: Path to array. |
| `splice`                        | `(path: string \| (string \| number)[], start: number, deleteCount?: number \| undefined, ...items: any[]): any[]` | Starting from the start index specified, removes 0 or more items<br />from the array and inserts 0 or more new items in their place.<br /><br />The arguments after `path` and return value match that of<br />`Array.prototype.splice`.<br /><br />This method notifies other paths to the same array that a<br />splice occurred to the array.<br /><br />**path**: Path to array.<br />**start**: Index from which to start removing/inserting.<br />**deleteCount**: Number of items to remove.<br />**items**: Items to insert into array. |
| `typeForProperty`               | `(name: string): void`                           | Override point to provide a type to which to deserialize a value to<br />a given property.<br /><br />**name**: Name of property |
| `unlinkPaths`                   | `(path: string \| (string \| number)[]): void`   | Removes a data path alias previously established with `_linkPaths`.<br /><br />Note, the path to unlink should be the target (`to`) used when<br />linking the paths.<br /><br />**path**: Target path to unlink. |
| `unshift`                       | `(path: string \| (string \| number)[], ...items: any[]): number` | Adds items onto the beginning of the array at the path specified.<br /><br />The arguments after `path` and return value match that of<br />`Array.prototype.push`.<br /><br />This method notifies other paths to the same array that a<br />splice occurred to the array.<br /><br />**path**: Path to array.<br />**items**: Items to insert info array |
| `updateStyles`                  | `(properties?: object \| null \| undefined): void` | When using the ShadyCSS scoping and custom property shim, causes all<br />shimmed styles in this element (and its subtree) to be updated<br />based on current custom property values.<br /><br />The optional parameter overrides inline custom property styles with an<br />object of properties where the keys are CSS properties, and the values<br />are strings.<br /><br />Example: `this.updateStyles({'--color': 'blue'})`<br /><br />These properties are retained unless a value of `null` is set.<br /><br />Note: This function does not support updating CSS mixins.<br />You can not dynamically change the value of an `@apply`.<br /><br />**properties**: Bag of custom property key/values to<br />apply to this element. |

## Events

| Event        | Description           |
|--------------|-----------------------|
| `test-event` | My super custom event |

</details>