### PR TITLE
Add Web-Types generation support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ node_modules
 dist
 lib
 *.tgz
+yarn.lock
 

--- a/README.md
+++ b/README.md
@@ -59,15 +59,15 @@ The analyze command analyses an optional `<input glob>` and emits the output to 
 ### Options
 
 <!-- prettier-ignore -->
-| Option                      | Type                             | Description                                                                  |
-| --------------------------- | -------------------------------- | ---------------------------------------------------------------------------- |
-| `--format <format>`         | `markdown` \| `json` \| `vscode` | Specify output format. Default is `markdown`.                                |
-| `--outDir <path>`           | `directory path`                 | Direct output to a directory where each file corresponds to a web component. |
-| `--outFile <path>`          | `file path`                      | Concatenate and emit output to a single file.                                |
-| `--outFiles <path>`         | `file path with pattern`         | Emit output to multiple files using a pattern. Available substitutions:<br>**{dir}**: The directory of the component<br>**{filename}**: The filename (without ext) of the component<br>**{tagname}**: The element's tag name |
-| `--visibility <visibility>` | `public` \| `protected` \| `private`   | The mininmum member visibility to output. Default is `public`.               |
-| `--features <features>` | `member` \| `method` \| `cssproperty` \| `csspart` \| `event` \| `slot`   | Choose specific features to output. Multiple features are given seperated by a space. All features are enabled as default.<br>**Example**: `--features member slot event`               |
-| `--dry`                     | `boolean`                        | Don't write any files  |
+| Option                      | Type                     | Description                                                                  |
+|-----------------------------|--------------------------| ---------------------------------------------------------------------------- |
+| `--format <format>`         | `markdown` \             | `json` \| `vscode` \| `webtypes` | Specify output format. Default is `markdown`.                                |
+| `--outDir <path>`           | `directory path`         | Direct output to a directory where each file corresponds to a web component. |
+| `--outFile <path>`          | `file path`              | Concatenate and emit output to a single file.                                |
+| `--outFiles <path>`         | `file path with pattern` | Emit output to multiple files using a pattern. Available substitutions:<br>**{dir}**: The directory of the component<br>**{filename}**: The filename (without ext) of the component<br>**{tagname}**: The element's tag name |
+| `--visibility <visibility>` | `public` \               | `protected` \| `private`   | The mininmum member visibility to output. Default is `public`.               |
+| `--features <features>`     | `member` \               | `method` \| `cssproperty` \| `csspart` \| `event` \| `slot`   | Choose specific features to output. Multiple features are given seperated by a space. All features are enabled as default.<br>**Example**: `--features member slot event`               |
+| `--dry`                     | `boolean`                | Don't write any files  |
 
 [![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/colored.png)](#api)
 
@@ -110,6 +110,17 @@ VSCode supports a JSON format called [vscode custom data](https://github.com/mic
 [![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/colored.png)](#how-does-this-tool-analyze-my-components)
 
 [![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/colored.png)](#how-to-document-your-components-using-jsdoc)
+
+### webtypes
+
+<!-- prettier-ignore -->
+```bash
+wca analyze src --format webtypes --outFile web-types-custom.json --webtypesConfig='{"name": "web-types-custom", "version": "0.0.1", "description-markup": "markdown"}'
+```
+
+Web-types format is a description for IDE completion, see [web-types](https://github.com/JetBrains/web-types/tree/master/packages)
+
+See [web-types dedicated page](./doc/web-types.md) for project setup.
 
 ## ➤ How to document your components using JSDoc
 

--- a/README.md
+++ b/README.md
@@ -107,10 +107,6 @@ wca analyze src --format vscode --outFile vscode-html-custom-data.json
 
 VSCode supports a JSON format called [vscode custom data](https://github.com/microsoft/vscode-custom-data) for the built in html editor which is set using `html.customData` vscode setting. Web Component Analyzer can output this format.
 
-[![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/colored.png)](#how-does-this-tool-analyze-my-components)
-
-[![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/colored.png)](#how-to-document-your-components-using-jsdoc)
-
 ### webtypes
 
 <!-- prettier-ignore -->
@@ -121,6 +117,10 @@ wca analyze src --format webtypes --outFile web-types-custom.json --webtypesConf
 Web-types format is a description for IDE completion, see [web-types](https://github.com/JetBrains/web-types/tree/master/packages)
 
 See [web-types dedicated page](./doc/web-types.md) for project setup.
+
+[![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/colored.png)](#how-does-this-tool-analyze-my-components)
+
+[![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/colored.png)](#how-to-document-your-components-using-jsdoc)
 
 ## ➤ How to document your components using JSDoc
 

--- a/doc/web-types.md
+++ b/doc/web-types.md
@@ -1,0 +1,85 @@
+# Web-types
+
+## Project setup
+
+### For Lit
+
+Generated web-types are working with the generic `lit-web-types` library. You need to add it on your project.
+
+<!-- prettier-ignore -->
+```bash
+npm i lit-web-types -D
+```
+
+Generate your components descriptions with wca
+
+<!-- prettier-ignore -->
+```bash
+wca analyze src --format webtypes --outFile web-types-custom.json --webtypesConfig='{"name": "web-types-custom", "version": "0.0.1", "description-markup": "markdown", "framework": "lit"}'
+```
+
+`--webtypesConfig` is a json object of web-types root parameters. Working with lit, `framework` must have `lit` value.
+See "Web types config parameters" documentation section for more info.
+
+Link your generated web-types file in your package.json
+
+```json
+{
+  ...,
+  "web-types": [
+    "./web-types-custom.json"
+  ]
+}
+```
+
+After the first setup on Intellij, IDE restart might be needed to enable components completion.
+
+### For Polymer
+
+Generated web-types are working with the generic `polymer-web-types` library. You need to add it on your project.
+
+<!-- prettier-ignore -->
+```bash
+npm i polymer-web-types -D
+```
+
+Generate your components descriptions with wca
+
+<!-- prettier-ignore -->
+```bash
+wca analyze src --format webtypes --outFile web-types-custom.json --webtypesConfig='{"name": "web-types-custom", "version": "0.0.1", "description-markup": "markdown", "framework": "@polymer/polymer"}'
+```
+
+`--webtypesConfig` is a json object of web-types root parameters. Working with polymer, `framework` must have `@polymer/polymer` value.
+See "Web types config parameters" documentation section for more info.
+
+Link your generated web-types file in your package.json
+
+```json
+{
+  ...,
+  "web-types": [
+    "./web-types-custom.json"
+  ]
+}
+```
+
+After the first setup on Intellij, IDE restart might be needed to enable components completion.
+
+## Web types config parameters
+
+`--webtypesConfig` parameter is a json object containing web-types file root parameter.
+
+Available parameters:
+
+| Name               | Description                                                                                                   |
+| ------------------ | ------------------------------------------------------------------------------------------------------------- |
+| name               | Name of library, mandatory option                                                                             |
+| version            | Version of the library, for which Web-Types are provided, mandatory option                                    |
+| framework          | See [http://json.schemastore.org/web-types](http://json.schemastore.org/web-types) framework section          |
+| js-types-syntax    | See [http://json.schemastore.org/web-types](http://json.schemastore.org/web-types) js-types-syntax section    |
+| description-markup | See [http://json.schemastore.org/web-types](http://json.schemastore.org/web-types) description-markup section |
+| framework-config   | See [http://json.schemastore.org/web-types](http://json.schemastore.org/web-types) framework-config section   |
+| default-icon       | See [http://json.schemastore.org/web-types](http://json.schemastore.org/web-types) default-icon section       |
+
+See [web-types project:](https://github.com/JetBrains/web-types) for more info.

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
 	"keywords": [
 		"web components",
 		"web",
-		"components"
+		"components",
+		"web-types"
 	],
 	"contributors": [
 		{

--- a/src/cli/analyze/analyze-cli-command.ts
+++ b/src/cli/analyze/analyze-cli-command.ts
@@ -23,7 +23,7 @@ export const analyzeCliCommand: CliCommand = async (config: AnalyzerCliConfig): 
 	const inputGlobs = config.glob || [];
 
 	// Log warning for experimental json format
-	if (config.format === "json" || config.format === "json2" || config.outFile?.endsWith(".json")) {
+	if (config.format === "json" || config.format === "json2" || (config.outFile?.endsWith(".json") && config.format !== "webtypes")) {
 		log(
 			`
 !!!!!!!!!!!!!  WARNING !!!!!!!!!!!!!
@@ -35,6 +35,12 @@ Please follow and contribute to the discussion at:
 `,
 			config
 		);
+	}
+
+	if (config.format === "webtypes") {
+		const webTypesConfig = config.webtypesConfig ? JSON.parse(config.webtypesConfig) : null;
+		if (!webTypesConfig.name) throw makeCliError('Missing webtypes-config "name" property');
+		if (!webTypesConfig.version) throw makeCliError('Missing webtypes-config "version" property');
 	}
 
 	// If no "out" is specified, output to console
@@ -124,6 +130,9 @@ function transformResults(results: AnalyzerResult[] | AnalyzerResult, program: P
 		markdown: config.markdown,
 		cwd: config.cwd
 	};
+	if (format == "webtypes") {
+		transformerConfig.webTypes = config.webtypesConfig ? JSON.parse(config.webtypesConfig) : null;
+	}
 
 	return transformAnalyzerResult(format, results, program, transformerConfig);
 }

--- a/src/cli/analyze/analyze-cli-command.ts
+++ b/src/cli/analyze/analyze-cli-command.ts
@@ -227,6 +227,7 @@ function formatToExtension(kind: TransformerKind): string {
 	switch (kind) {
 		case "json":
 		case "vscode":
+		case "webtypes":
 			return ".json";
 		case "md":
 		case "markdown":

--- a/src/cli/analyze/analyze-cli-command.ts
+++ b/src/cli/analyze/analyze-cli-command.ts
@@ -128,7 +128,8 @@ function transformResults(results: AnalyzerResult[] | AnalyzerResult, program: P
 		inlineTypes: config.inlineTypes ?? false,
 		visibility: config.visibility ?? "public",
 		markdown: config.markdown,
-		cwd: config.cwd
+		cwd: config.cwd,
+		pathAsAbsolute: config.pathAsAbsolute
 	};
 	if (format == "webtypes") {
 		transformerConfig.webTypes = config.webtypesConfig ? JSON.parse(config.webtypesConfig) : null;

--- a/src/cli/analyzer-cli-config.ts
+++ b/src/cli/analyzer-cli-config.ts
@@ -30,4 +30,6 @@ export interface AnalyzerCliConfig {
 
 	ts?: typeof tsModule;
 	cwd?: string;
+
+	webtypesConfig?: string;
 }

--- a/src/cli/analyzer-cli-config.ts
+++ b/src/cli/analyzer-cli-config.ts
@@ -30,6 +30,7 @@ export interface AnalyzerCliConfig {
 
 	ts?: typeof tsModule;
 	cwd?: string;
+	pathAsAbsolute?: boolean;
 
 	webtypesConfig?: string;
 }

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -50,7 +50,7 @@ o {tagname}: The element's tag name`,
 		})
 		.option("format", {
 			describe: `Specify output format`,
-			choices: ["md", "markdown", "json", "json2", "vscode"],
+			choices: ["md", "markdown", "json", "json2", "vscode", "webtypes"],
 			nargs: 1,
 			alias: "f"
 		})

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -103,7 +103,12 @@ o {tagname}: The element's tag name`,
 			string: true,
 			hidden: true
 		})
-		.option("webtypes-config", {
+		.option("pathAsAbsolute", {
+			describe: "Consider paths as absolute: don't add './' in front of paths",
+			boolean: true,
+			hidden: true
+		})
+		.option("webtypesConfig", {
 			describe: "WebTypes header configuration",
 			string: true
 		})

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -103,6 +103,10 @@ o {tagname}: The element's tag name`,
 			string: true,
 			hidden: true
 		})
+		.option("webtypes-config", {
+			describe: "WebTypes header configuration",
+			string: true
+		})
 
 		.alias("v", "version")
 		.help("h")

--- a/src/transformers/transform-analyzer-result.ts
+++ b/src/transformers/transform-analyzer-result.ts
@@ -8,6 +8,7 @@ import { TransformerConfig } from "./transformer-config";
 import { TransformerFunction } from "./transformer-function";
 import { TransformerKind } from "./transformer-kind";
 import { vscodeTransformer } from "./vscode/vscode-transformer";
+import { webtypesTransformer } from "./webtypes/webtypes-transformer";
 
 const transformerFunctionMap: Record<TransformerKind, TransformerFunction> = {
 	debug: debugJsonTransformer,
@@ -15,7 +16,8 @@ const transformerFunctionMap: Record<TransformerKind, TransformerFunction> = {
 	json2: json2Transformer,
 	markdown: markdownTransformer,
 	md: markdownTransformer,
-	vscode: vscodeTransformer
+	vscode: vscodeTransformer,
+	webtypes: webtypesTransformer
 };
 
 /**

--- a/src/transformers/transformer-config.ts
+++ b/src/transformers/transformer-config.ts
@@ -3,6 +3,7 @@ import { GenericContributions } from "./webtypes/webtypes-schema";
 
 export interface TransformerConfig {
 	cwd?: string;
+	pathAsAbsolute?: boolean;
 	visibility?: VisibilityKind;
 	markdown?: {
 		titleLevel?: number; // deprecated

--- a/src/transformers/transformer-config.ts
+++ b/src/transformers/transformer-config.ts
@@ -1,4 +1,5 @@
 import { VisibilityKind } from "../analyze/types/visibility-kind";
+import { GenericContributions } from "./webtypes/webtypes-schema";
 
 export interface TransformerConfig {
 	cwd?: string;
@@ -8,4 +9,19 @@ export interface TransformerConfig {
 		headerLevel?: number;
 	};
 	inlineTypes?: boolean;
+	webTypes?: WebTypesTransformerConfig;
+}
+
+export interface WebTypesTransformerConfig {
+	name: string;
+	version: string;
+	"default-icon"?: string;
+	"js-types-syntax"?: "typescript";
+	framework?: string;
+	"framework-config"?: WebTypesFrameworkConfig;
+	"description-markup"?: "html" | "markdown" | "none";
+}
+
+export interface WebTypesFrameworkConfig {
+	[k: string]: GenericContributions;
 }

--- a/src/transformers/transformer-kind.ts
+++ b/src/transformers/transformer-kind.ts
@@ -1,1 +1,1 @@
-export type TransformerKind = "md" | "markdown" | "json" | "vscode" | "debug" | "json2";
+export type TransformerKind = "md" | "markdown" | "json" | "vscode" | "debug" | "json2" | "webtypes";

--- a/src/transformers/webtypes/webtypes-schema.ts
+++ b/src/transformers/webtypes/webtypes-schema.ts
@@ -1,0 +1,109 @@
+// converted from JSON schema with https://transform.tools/json-schema-to-typescript
+// just renamed JSONSchemaForWebTypesPreviewOfVersion20OfTheStandard to WebtypesSchema
+
+/**
+ * Language in which JavaScript objects types are specified.
+ */
+export type JsTypesSyntax = "typescript";
+/**
+ * Markup language in which descriptions are formatted
+ */
+export type DescriptionMarkup = "html" | "markdown" | "none";
+/**
+ * A RegEx pattern to match whole content. Syntax should work with at least ECMA, Java and Python implementations.
+ */
+export type Pattern =
+	| string
+	| {
+			regex?: string;
+			"case-sensitive"?: boolean;
+			[k: string]: unknown;
+	  };
+export type NameConverter = "as-is" | "PascalCase" | "camelCase" | "lowercase" | "UPPERCASE" | "kebab-case" | "snake_case";
+export type NameConverters = NameConverter[];
+/**
+ * Relative path to icon
+ */
+export type Icon = string;
+export type Html = GenericContributionsHost;
+export type GenericContributions = GenericContributionOrProperty[] | GenericContributionOrProperty;
+export type GenericContributionOrProperty = string | number | boolean | GenericContribution;
+export type GenericContribution = TypedContribution;
+export type TypedContribution = BaseContribution;
+export type BaseContribution = GenericContributionsHost;
+export type Css = GenericContributionsHost;
+export type Js = GenericContributionsHost;
+
+export interface WebtypesSchema {
+	$schema?: string;
+	/**
+	 * Framework, for which the components are provided by the library
+	 */
+	framework?: string;
+	/**
+	 * Name of the library
+	 */
+	name: string;
+	/**
+	 * Version of the library, for which web-types are provided
+	 */
+	version: string;
+	"js-types-syntax"?: JsTypesSyntax;
+	"description-markup"?: DescriptionMarkup;
+	"framework-config"?: FrameworkConfig;
+	"default-icon"?: Icon;
+	contributions?: {
+		html?: Html;
+		css?: Css;
+		js?: Js;
+	};
+}
+export interface FrameworkConfig {
+	/**
+	 * Specify rules for enabling web framework support.
+	 */
+	"enable-when"?: {
+		/**
+		 * Node.js package names, which enable framework support within the folder containing the package.json.
+		 */
+		"node-packages"?: string[];
+		/**
+		 * RegExps to match script URLs, which enable framework support within a particular HTML.
+		 */
+		"script-url-patterns"?: Pattern[];
+		/**
+		 * Extensions of files, which should have the framework support enabled
+		 */
+		"file-extensions"?: string[];
+		/**
+		 * RegExp patterns to match file names, which should have the framework support enabled
+		 */
+		"file-name-patterns"?: Pattern[];
+		/**
+		 * Global JavaScript libraries names enabled within the IDE, which enable framework support in the whole project
+		 */
+		"ide-libraries"?: string[];
+	};
+	/**
+	 * Specify rules for disabling web framework support. These rules take precedence over enable-when rules.
+	 */
+	"disable-when"?: {
+		/**
+		 * Extensions of files, which should have the framework support disabled
+		 */
+		"file-extensions"?: string[];
+		/**
+		 * RegExp patterns to match file names, which should have the framework support disabled
+		 */
+		"file-name-patterns"?: Pattern[];
+	};
+	"canonical-names"?: {
+		[k: string]: NameConverter;
+	};
+	"name-variants"?: {
+		[k: string]: NameConverters;
+	};
+}
+export interface GenericContributionsHost {
+	[k: string]: GenericContributions;
+}

--- a/src/transformers/webtypes/webtypes-schema.ts
+++ b/src/transformers/webtypes/webtypes-schema.ts
@@ -21,18 +21,22 @@ export type Pattern =
 	  };
 export type NameConverter = "as-is" | "PascalCase" | "camelCase" | "lowercase" | "UPPERCASE" | "kebab-case" | "snake_case";
 export type NameConverters = NameConverter[];
+
+export type Priority = "lowest" | "low" | "normal" | "high" | "highest";
 /**
  * Relative path to icon
  */
 export type Icon = string;
-export type Html = GenericContributionsHost;
+// export type Html = GenericContributionsHost;
 export type GenericContributions = GenericContributionOrProperty[] | GenericContributionOrProperty;
-export type GenericContributionOrProperty = string | number | boolean | GenericContribution;
+export type GenericContributionOrProperty = string | number | boolean | GenericContribution | Source;
 export type GenericContribution = TypedContribution;
-export type TypedContribution = BaseContribution;
-export type BaseContribution = GenericContributionsHost;
+
+export interface TypedContribution extends BaseContribution {
+	type?: Type | Type[];
+}
+
 export type Css = GenericContributionsHost;
-export type Js = GenericContributionsHost;
 
 export interface WebtypesSchema {
 	$schema?: string;
@@ -107,3 +111,88 @@ export interface FrameworkConfig {
 export interface GenericContributionsHost {
 	[k: string]: GenericContributions;
 }
+
+export interface SourceFile {
+	file: string;
+	offset: number;
+}
+
+export interface SourceModule {
+	module: string;
+	symbol: string;
+}
+
+export type Source = SourceFile | SourceModule;
+
+export type Html = HtmlContributionHost;
+
+export interface HtmlElement extends BaseContribution, HtmlContributionHost {}
+
+export interface BaseContribution {
+	// #/definitions/base-contribution
+	// [k: string]: GenericContributions;
+	name?: string;
+	description?: string;
+	// "description-sections"?: ;
+	"doc-url"?: string;
+	icon?: Icon;
+	source?: Source;
+	deprecated?: boolean;
+	experimental?: boolean;
+	priority?: Priority;
+	proximity?: number;
+	virtual?: boolean;
+	abstract?: boolean;
+	extension?: boolean;
+	extends?: Reference;
+	// pattern?: NamePatternRoot;
+	html?: Html;
+	css?: Css;
+	js?: Js;
+	// "exclusive-contributions"?: ;
+}
+
+export interface HtmlContributionHost {
+	elements?: HtmlElement[];
+	attributes?: HtmlAttribute[];
+}
+
+export interface HtmlAttribute extends BaseContribution, HtmlContributionHost {
+	value?: HtmlAttributeValue;
+	default?: string;
+	required?: boolean;
+}
+
+export interface HtmlAttributeValue {
+	type?: Type | Type[];
+	required?: boolean;
+	default?: string;
+	kind?: HtmlAttributeType;
+}
+
+export interface TypeReference {
+	module?: string;
+	name: string;
+}
+
+export type Type = string | TypeReference;
+
+export type HtmlAttributeType = "no-value" | "plain" | "expression";
+
+export type Reference = string | ReferenceWithProps;
+
+export interface ReferenceWithProps {
+	path: string;
+	includeVirtual?: boolean;
+	includeAbstract?: boolean;
+	filter?: string;
+}
+
+export type Js = JsContributionsHost;
+
+export interface JsContributionsHost {
+	events?: GenericJsContribution[];
+	properties?: GenericJsContribution[];
+}
+
+export interface GenericJsContribution extends GenericContribution, JsContributionsHost {}

--- a/src/transformers/webtypes/webtypes-schema.ts
+++ b/src/transformers/webtypes/webtypes-schema.ts
@@ -36,8 +36,6 @@ export interface TypedContribution extends BaseContribution {
 	type?: Type | Type[];
 }
 
-export type Css = GenericContributionsHost;
-
 export interface WebtypesSchema {
 	$schema?: string;
 	/**
@@ -196,3 +194,27 @@ export interface JsContributionsHost {
 }
 
 export interface GenericJsContribution extends GenericContribution, JsContributionsHost {}
+
+export type Css = CssContributionsHost;
+
+export interface CssContributionsHost {
+	properties?: CssProperty[];
+	"pseudo-elements"?: CssPseudoElement[];
+	"pseudo-classes"?: CssPseudoClass[];
+	functions?: CssGenericItem[];
+	classes?: CssGenericItem[];
+}
+
+export interface CssProperty extends BaseContribution, CssContributionsHost {
+	values?: string[];
+}
+
+export interface CssPseudoElement extends BaseContribution, CssContributionsHost {
+	arguments?: boolean;
+}
+
+export interface CssPseudoClass extends BaseContribution, CssContributionsHost {
+	arguments?: boolean;
+}
+
+export interface CssGenericItem extends BaseContribution, CssContributionsHost {}

--- a/src/transformers/webtypes/webtypes-schema.ts
+++ b/src/transformers/webtypes/webtypes-schema.ts
@@ -27,7 +27,6 @@ export type Priority = "lowest" | "low" | "normal" | "high" | "highest";
  * Relative path to icon
  */
 export type Icon = string;
-// export type Html = GenericContributionsHost;
 export type GenericContributions = GenericContributionOrProperty[] | GenericContributionOrProperty;
 export type GenericContributionOrProperty = string | number | boolean | GenericContribution | Source;
 export type GenericContribution = TypedContribution;
@@ -106,9 +105,6 @@ export interface FrameworkConfig {
 		[k: string]: NameConverters;
 	};
 }
-export interface GenericContributionsHost {
-	[k: string]: GenericContributions;
-}
 
 export interface SourceFile {
 	file: string;
@@ -127,8 +123,6 @@ export type Html = HtmlContributionHost;
 export interface HtmlElement extends BaseContribution, HtmlContributionHost {}
 
 export interface BaseContribution {
-	// #/definitions/base-contribution
-	// [k: string]: GenericContributions;
 	name?: string;
 	description?: string;
 	// "description-sections"?: ;

--- a/src/transformers/webtypes/webtypes-transformer.ts
+++ b/src/transformers/webtypes/webtypes-transformer.ts
@@ -1,17 +1,15 @@
-import { getTypeHintFromMethod } from "../../util/get-type-hint-from-method";
 import { getTypeHintFromType } from "../../util/get-type-hint-from-type";
-import { isAssignableToSimpleTypeKind, isSimpleType, SimpleType, toSimpleType, typeToString } from "ts-simple-type";
-import { Program, Type, TypeChecker } from "typescript";
+import { Program, TypeChecker } from "typescript";
 import { AnalyzerResult } from "../../analyze/types/analyzer-result";
 import { ComponentDefinition } from "../../analyze/types/component-definition";
 import { ComponentEvent } from "../../analyze/types/features/component-event";
 import { ComponentMember } from "../../analyze/types/features/component-member";
-import { JsDoc } from "../../analyze/types/js-doc";
 import { arrayDefined } from "../../util/array-util";
-import { markdownHighlight } from "../markdown/markdown-util";
 import { TransformerConfig } from "../transformer-config";
 import { TransformerFunction } from "../transformer-function";
-import { GenericContributionsHost, WebtypesSchema } from "./webtypes-schema";
+import { HtmlAttribute, GenericContributionsHost, WebtypesSchema, HtmlElement, BaseContribution, Js } from "./webtypes-schema";
+import { getFirst } from "../../util/set-util";
+import { relative } from "path";
 
 /**
  * Transforms results to json.
@@ -29,73 +27,21 @@ export const webtypesTransformer: TransformerFunction = (results: AnalyzerResult
 	const elements = definitions.map(d => definitionToHTMLElement(d, checker, config));
 
 	const webtypesJson: WebtypesSchema = {
-		$schema: "https://raw.githubusercontent.com/JetBrains/web-types/master/v2-preview/web-types.json",
+		$schema: "http://json.schemastore.org/web-types",
 		name: "web-components", // TODO as param
 		version: "experimental",
 		//"default-icon": "icons/lit.png",
 		"js-types-syntax": "typescript", // TODO as param
-		framework: "lit",
-		"framework-config": {
-			"enable-when": {
-				"node-packages": ["lit"],
-				"file-extensions": ["ts", "js", "tsx", "jsx"]
-			}
-		},
+		// framework: "lit",
+		// "framework-config": {
+		// 	"enable-when": {
+		// 		"node-packages": ["lit"],
+		// 		"file-extensions": ["ts", "js", "tsx", "jsx"]
+		// 	}
+		// },
 		contributions: {
 			html: {
 				elements: elements
-				/*
-				attributes: [
-					{
-						"name": "Event listeners",
-						"description": "Event listeners expression",
-						"doc-url": "https://lit.dev/docs/templates/expressions/#event-listener-expressions",
-						"value": {
-							"kind": "expression",
-							"type": "(event: Event) => void"
-						},
-						"pattern": {
-							"items": "/html/events",
-							"template": [
-								"@",
-								"#item:event name"
-							]
-						}
-					},
-					{
-						"name": "Boolean Attributes",
-						"description": "Boolean Attributes expression",
-						"doc-url": "https://lit.dev/docs/templates/expressions/#boolean-attribute-expressions",
-						"value": {
-							"kind": "expression",
-							"type": "boolean"
-						},
-						"pattern": {
-							"items": "/html/attributes",
-							"template": [
-								"?",
-								"#item:attribute name"
-							]
-						}
-					},
-					{
-						"name": "Properties",
-						"description": "Properties expression",
-						"doc-url": "https://lit.dev/docs/templates/expressions/#property-expressions",
-						"value": {
-							"kind": "expression",
-							"type": "any"
-						},
-						"pattern": {
-							"items": "/html/attributes",
-							"template": [
-								".",
-								"#item:property name"
-							]
-						}
-					}
-				]
-				 */
 			}
 		}
 	};
@@ -103,7 +49,7 @@ export const webtypesTransformer: TransformerFunction = (results: AnalyzerResult
 	return JSON.stringify(webtypesJson, null, 4);
 };
 
-function definitionToHTMLElement(definition: ComponentDefinition, checker: TypeChecker, config: TransformerConfig): GenericContributionsHost {
+function definitionToHTMLElement(definition: ComponentDefinition, checker: TypeChecker, config: TransformerConfig): HtmlElement {
 	const declaration = definition.declaration;
 
 	if (declaration == null) {
@@ -113,173 +59,81 @@ function definitionToHTMLElement(definition: ComponentDefinition, checker: TypeC
 		};
 	}
 
-	/*
-	// Transform all members into "attributes"
-	const customElementAttributes = arrayDefined(declaration.members.map(d => componentMemberToVscodeAttr(d, checker)));
-	const eventAttributes = arrayDefined(declaration.events.map(e => componentEventToVscodeAttr(e, checker)));
-
-	const attributes = [...customElementAttributes, ...eventAttributes];
-*/
-	const customElementAttributes = arrayDefined(declaration.members.map(d => componentMemberToAttr(d, checker, config)));
-	const eventAttributes = arrayDefined(declaration.events.map(e => componentEventToAttr(e, checker, config)));
-
-	const attributes = [...customElementAttributes, ...eventAttributes];
-
-	return {
-		name: definition.tagName,
-		/*
-		description: formatMetadata(declaration.jsDoc, {
-			Events: declaration.events.map(e => formatEntryRow(e.name, e.jsDoc, e.type?.(), checker)),
-			Slots: declaration.slots.map(s =>
-				formatEntryRow(s.name || " ", s.jsDoc, s.permittedTagNames && s.permittedTagNames.map(n => `"${markdownHighlight(n)}"`).join(" | "), checker)
-			),
-			Attributes: declaration.members
-				.map(m => ("attrName" in m && m.attrName != null ? formatEntryRow(m.attrName, m.jsDoc, m.typeHint || m.type?.(), checker) : undefined))
-				.filter(m => m != null),
-			Properties: declaration.members
-				.map(m => ("propName" in m && m.propName != null ? formatEntryRow(m.propName, m.jsDoc, m.typeHint || m.type?.(), checker) : undefined))
-				.filter(m => m != null)
-		}),
-*/
-		attributes: attributes
+	const build: HtmlElement = {
+		name: definition.tagName
 	};
+
+	// Build description
+	if (declaration?.jsDoc?.description) build.description = declaration.jsDoc.description;
+
+	// Build source section
+	const node = getFirst(definition.identifierNodes);
+	const fileName = node?.getSourceFile().fileName;
+	const path = fileName != null && config.cwd != null ? `./${relative(config.cwd, fileName)}` : undefined;
+
+	if (node?.getText() && path) {
+		build.source = {
+			module: path,
+			symbol: node.getText()
+		};
+	}
+
+	// Build attributes
+	const customElementAttributes = arrayDefined(declaration.members.map(d => componentMemberToAttr(d.attrName, d, checker, config)));
+	if (customElementAttributes.length > 0) build.attributes = customElementAttributes;
+
+	const js: Js = {};
+
+	// Build properties
+	const customElementProperties = arrayDefined(declaration.members.map(d => componentMemberToAttr(d.propName, d, checker, config)));
+	if (customElementProperties.length > 0) js.properties = customElementProperties;
+
+	// Build events
+	const eventAttributes = arrayDefined(declaration.events.map(e => componentEventToAttr(e, checker, config)));
+	if (eventAttributes.length > 0) js.events = eventAttributes;
+
+	if (js.properties || js.events) build.js = js;
+
+	return build;
 }
 
 function componentEventToAttr(event: ComponentEvent, checker: TypeChecker, config: TransformerConfig): GenericContributionsHost | undefined {
 	return {
-		name: `@${event.name}`
+		name: event.name
 	};
 }
 
-function componentMemberToAttr(member: ComponentMember, checker: TypeChecker, config: TransformerConfig): GenericContributionsHost | undefined {
-	if (member.propName == null) {
+function componentMemberToAttr(
+	propName: string | undefined,
+	member: ComponentMember,
+	checker: TypeChecker,
+	config: TransformerConfig
+): BaseContribution | undefined {
+	if (propName == null) {
 		return undefined;
 	}
 
-	const isFunction = member.attrName == null;
+	// const isFunction = member.attrName == null;
 
-	let types: string[] | string = getTypeHintFromType(member.typeHint ?? member.type?.(), checker, config)?.split(" | ") ?? [];
-	if (isFunction) {
-		types = []; // TODO find a way to support function signatures, types includes signature as string
-	}
+	const types: string[] | string = getTypeHintFromType(member.typeHint ?? member.type?.(), checker, config)?.split(" | ") ?? [];
+	// if (isFunction) {
+	// 	types = []; // TODO find a way to support function signatures, types includes signature as string
+	// }
+	//
+	// if (types.length == 1) {
+	// 	types = types[0];
+	// }
 
-	let name = member.propName;
-	if (isFunction || types.length == 0 || types.includes("Object")) {
-		name = "." + name;
-	} else if (types.length == 1 && types.includes("boolean")) {
-		name = "?" + name;
-	}
-
-	if (types.length == 1) {
-		types = types[0];
-	}
-
-	return {
-		name: name,
+	const attr: HtmlAttribute = {
+		name: propName,
 		value: {
 			type: types,
-			required: new Boolean(member.required).valueOf()
-			//default: member.default // TODO has some strange values
+			required: new Boolean(member.required).valueOf(),
+			...(member.default !== undefined ? { default: JSON.stringify(member.default) } : {})
 		}
-		/*
-		description: formatMetadata(formatEntryRow(member.attrName, member.jsDoc, member.typeHint || member.type?.(), checker), {
-			Property: "propName" in member ? member.propName : undefined,
-			Default: member.default === undefined ? undefined : String(member.default)
-		}),
-		...((member.type && typeToVscodeValuePart(member.type?.(), checker)) || {})
-*/
 	};
-}
 
-/**
- * Converts a type to either a value set or string unions.
- * @param type
- * @param checker
- */
-function typeToVscodeValuePart(type: SimpleType | Type, checker: TypeChecker): { valueSet: "v" } | { values: HtmlDataAttrValue[] } | undefined {
-	const simpleType = isSimpleType(type) ? type : toSimpleType(type, checker);
+	if (member?.jsDoc?.description) attr.description = member.jsDoc.description;
 
-	switch (simpleType.kind) {
-		case "BOOLEAN":
-			return { valueSet: "v" };
-		case "STRING_LITERAL":
-			return { values: [{ name: simpleType.value }] };
-		case "ENUM":
-			return { values: typesToStringUnion(simpleType.types.map(({ type }) => type)) };
-		case "UNION":
-			return { values: typesToStringUnion(simpleType.types) };
-	}
-
-	return undefined;
-}
-
-/**
- * Returns a list of strings that represents the types.
- * Only looks at literal types and strips the rest.
- * @param types
- */
-function typesToStringUnion(types: SimpleType[]): HtmlDataAttrValue[] {
-	return arrayDefined(
-		types.map(t => {
-			switch (t.kind) {
-				case "STRING_LITERAL":
-				case "NUMBER_LITERAL":
-					return { name: t.value.toString() };
-				default:
-					return undefined;
-			}
-		})
-	);
-}
-
-/**
- * Formats description and metadata so that it can be used in documentation.
- * @param doc
- * @param metadata
- */
-function formatMetadata(
-	doc: string | undefined | JsDoc,
-	metadata: { [key: string]: string | undefined | (string | undefined)[] }
-): string | undefined {
-	const metaText = arrayDefined(
-		Object.entries(metadata).map(([key, value]) => {
-			if (value == null) {
-				return undefined;
-			} else if (Array.isArray(value)) {
-				const filtered = arrayDefined(value);
-				if (filtered.length === 0) return undefined;
-
-				return `${key}:\n\n${filtered.map(v => `  * ${v}`).join(`\n\n`)}`;
-			} else {
-				return `${key}: ${value}`;
-			}
-		})
-	).join(`\n\n`);
-
-	const comment = typeof doc === "string" ? doc : doc?.description || "";
-
-	return `${comment || ""}${metadata ? `${comment ? `\n\n` : ""}${metaText}` : ""}` || undefined;
-}
-
-/**
- * Formats name, doc and type so that it can be presented in documentation
- * @param name
- * @param doc
- * @param type
- * @param checker
- */
-function formatEntryRow(name: string, doc: JsDoc | string | undefined, type: Type | SimpleType | string | undefined, checker: TypeChecker): string {
-	const comment = typeof doc === "string" ? doc : doc?.description || "";
-	const typeText = typeof type === "string" ? type : type == null ? "" : formatType(type, checker);
-
-	return `${markdownHighlight(name)}${typeText == null ? "" : ` {${typeText}}`}${comment == null ? "" : " - "}${comment || ""}`;
-}
-
-/**
- * Formats a type to present in documentation
- * @param type
- * @param checker
- */
-function formatType(type: Type | SimpleType, checker: TypeChecker): string | undefined {
-	return !isAssignableToSimpleTypeKind(type, "ANY", checker) ? markdownHighlight(typeToString(type, checker)) : undefined;
+	return attr;
 }

--- a/src/transformers/webtypes/webtypes-transformer.ts
+++ b/src/transformers/webtypes/webtypes-transformer.ts
@@ -1,0 +1,285 @@
+import { getTypeHintFromMethod } from "../../util/get-type-hint-from-method";
+import { getTypeHintFromType } from "../../util/get-type-hint-from-type";
+import { isAssignableToSimpleTypeKind, isSimpleType, SimpleType, toSimpleType, typeToString } from "ts-simple-type";
+import { Program, Type, TypeChecker } from "typescript";
+import { AnalyzerResult } from "../../analyze/types/analyzer-result";
+import { ComponentDefinition } from "../../analyze/types/component-definition";
+import { ComponentEvent } from "../../analyze/types/features/component-event";
+import { ComponentMember } from "../../analyze/types/features/component-member";
+import { JsDoc } from "../../analyze/types/js-doc";
+import { arrayDefined } from "../../util/array-util";
+import { markdownHighlight } from "../markdown/markdown-util";
+import { TransformerConfig } from "../transformer-config";
+import { TransformerFunction } from "../transformer-function";
+import { GenericContributionsHost, WebtypesSchema } from "./webtypes-schema";
+
+/**
+ * Transforms results to json.
+ * @param results
+ * @param program
+ * @param config
+ */
+export const webtypesTransformer: TransformerFunction = (results: AnalyzerResult[], program: Program, config: TransformerConfig): string => {
+	const checker = program.getTypeChecker();
+
+	// Grab all definitions
+	const definitions = results.map(res => res.componentDefinitions).reduce((acc, cur) => [...acc, ...cur], []);
+
+	// Transform all definitions into "tags"
+	const elements = definitions.map(d => definitionToHTMLElement(d, checker, config));
+
+	const webtypesJson: WebtypesSchema = {
+		$schema: "https://raw.githubusercontent.com/JetBrains/web-types/master/v2-preview/web-types.json",
+		name: "web-components", // TODO as param
+		version: "experimental",
+		//"default-icon": "icons/lit.png",
+		"js-types-syntax": "typescript", // TODO as param
+		framework: "lit",
+		"framework-config": {
+			"enable-when": {
+				"node-packages": ["lit"],
+				"file-extensions": ["ts", "js", "tsx", "jsx"]
+			}
+		},
+		contributions: {
+			html: {
+				elements: elements
+				/*
+				attributes: [
+					{
+						"name": "Event listeners",
+						"description": "Event listeners expression",
+						"doc-url": "https://lit.dev/docs/templates/expressions/#event-listener-expressions",
+						"value": {
+							"kind": "expression",
+							"type": "(event: Event) => void"
+						},
+						"pattern": {
+							"items": "/html/events",
+							"template": [
+								"@",
+								"#item:event name"
+							]
+						}
+					},
+					{
+						"name": "Boolean Attributes",
+						"description": "Boolean Attributes expression",
+						"doc-url": "https://lit.dev/docs/templates/expressions/#boolean-attribute-expressions",
+						"value": {
+							"kind": "expression",
+							"type": "boolean"
+						},
+						"pattern": {
+							"items": "/html/attributes",
+							"template": [
+								"?",
+								"#item:attribute name"
+							]
+						}
+					},
+					{
+						"name": "Properties",
+						"description": "Properties expression",
+						"doc-url": "https://lit.dev/docs/templates/expressions/#property-expressions",
+						"value": {
+							"kind": "expression",
+							"type": "any"
+						},
+						"pattern": {
+							"items": "/html/attributes",
+							"template": [
+								".",
+								"#item:property name"
+							]
+						}
+					}
+				]
+				 */
+			}
+		}
+	};
+
+	return JSON.stringify(webtypesJson, null, 4);
+};
+
+function definitionToHTMLElement(definition: ComponentDefinition, checker: TypeChecker, config: TransformerConfig): GenericContributionsHost {
+	const declaration = definition.declaration;
+
+	if (declaration == null) {
+		return {
+			name: definition.tagName,
+			attributes: []
+		};
+	}
+
+	/*
+	// Transform all members into "attributes"
+	const customElementAttributes = arrayDefined(declaration.members.map(d => componentMemberToVscodeAttr(d, checker)));
+	const eventAttributes = arrayDefined(declaration.events.map(e => componentEventToVscodeAttr(e, checker)));
+
+	const attributes = [...customElementAttributes, ...eventAttributes];
+*/
+	const customElementAttributes = arrayDefined(declaration.members.map(d => componentMemberToAttr(d, checker, config)));
+	const eventAttributes = arrayDefined(declaration.events.map(e => componentEventToAttr(e, checker, config)));
+
+	const attributes = [...customElementAttributes, ...eventAttributes];
+
+	return {
+		name: definition.tagName,
+		/*
+		description: formatMetadata(declaration.jsDoc, {
+			Events: declaration.events.map(e => formatEntryRow(e.name, e.jsDoc, e.type?.(), checker)),
+			Slots: declaration.slots.map(s =>
+				formatEntryRow(s.name || " ", s.jsDoc, s.permittedTagNames && s.permittedTagNames.map(n => `"${markdownHighlight(n)}"`).join(" | "), checker)
+			),
+			Attributes: declaration.members
+				.map(m => ("attrName" in m && m.attrName != null ? formatEntryRow(m.attrName, m.jsDoc, m.typeHint || m.type?.(), checker) : undefined))
+				.filter(m => m != null),
+			Properties: declaration.members
+				.map(m => ("propName" in m && m.propName != null ? formatEntryRow(m.propName, m.jsDoc, m.typeHint || m.type?.(), checker) : undefined))
+				.filter(m => m != null)
+		}),
+*/
+		attributes: attributes
+	};
+}
+
+function componentEventToAttr(event: ComponentEvent, checker: TypeChecker, config: TransformerConfig): GenericContributionsHost | undefined {
+	return {
+		name: `@${event.name}`
+	};
+}
+
+function componentMemberToAttr(member: ComponentMember, checker: TypeChecker, config: TransformerConfig): GenericContributionsHost | undefined {
+	if (member.propName == null) {
+		return undefined;
+	}
+
+	const isFunction = member.attrName == null;
+
+	let types: string[] | string = getTypeHintFromType(member.typeHint ?? member.type?.(), checker, config)?.split(" | ") ?? [];
+	if (isFunction) {
+		types = []; // TODO find a way to support function signatures, types includes signature as string
+	}
+
+	let name = member.propName;
+	if (isFunction || types.length == 0 || types.includes("Object")) {
+		name = "." + name;
+	} else if (types.length == 1 && types.includes("boolean")) {
+		name = "?" + name;
+	}
+
+	if (types.length == 1) {
+		types = types[0];
+	}
+
+	return {
+		name: name,
+		value: {
+			type: types,
+			required: new Boolean(member.required).valueOf()
+			//default: member.default // TODO has some strange values
+		}
+		/*
+		description: formatMetadata(formatEntryRow(member.attrName, member.jsDoc, member.typeHint || member.type?.(), checker), {
+			Property: "propName" in member ? member.propName : undefined,
+			Default: member.default === undefined ? undefined : String(member.default)
+		}),
+		...((member.type && typeToVscodeValuePart(member.type?.(), checker)) || {})
+*/
+	};
+}
+
+/**
+ * Converts a type to either a value set or string unions.
+ * @param type
+ * @param checker
+ */
+function typeToVscodeValuePart(type: SimpleType | Type, checker: TypeChecker): { valueSet: "v" } | { values: HtmlDataAttrValue[] } | undefined {
+	const simpleType = isSimpleType(type) ? type : toSimpleType(type, checker);
+
+	switch (simpleType.kind) {
+		case "BOOLEAN":
+			return { valueSet: "v" };
+		case "STRING_LITERAL":
+			return { values: [{ name: simpleType.value }] };
+		case "ENUM":
+			return { values: typesToStringUnion(simpleType.types.map(({ type }) => type)) };
+		case "UNION":
+			return { values: typesToStringUnion(simpleType.types) };
+	}
+
+	return undefined;
+}
+
+/**
+ * Returns a list of strings that represents the types.
+ * Only looks at literal types and strips the rest.
+ * @param types
+ */
+function typesToStringUnion(types: SimpleType[]): HtmlDataAttrValue[] {
+	return arrayDefined(
+		types.map(t => {
+			switch (t.kind) {
+				case "STRING_LITERAL":
+				case "NUMBER_LITERAL":
+					return { name: t.value.toString() };
+				default:
+					return undefined;
+			}
+		})
+	);
+}
+
+/**
+ * Formats description and metadata so that it can be used in documentation.
+ * @param doc
+ * @param metadata
+ */
+function formatMetadata(
+	doc: string | undefined | JsDoc,
+	metadata: { [key: string]: string | undefined | (string | undefined)[] }
+): string | undefined {
+	const metaText = arrayDefined(
+		Object.entries(metadata).map(([key, value]) => {
+			if (value == null) {
+				return undefined;
+			} else if (Array.isArray(value)) {
+				const filtered = arrayDefined(value);
+				if (filtered.length === 0) return undefined;
+
+				return `${key}:\n\n${filtered.map(v => `  * ${v}`).join(`\n\n`)}`;
+			} else {
+				return `${key}: ${value}`;
+			}
+		})
+	).join(`\n\n`);
+
+	const comment = typeof doc === "string" ? doc : doc?.description || "";
+
+	return `${comment || ""}${metadata ? `${comment ? `\n\n` : ""}${metaText}` : ""}` || undefined;
+}
+
+/**
+ * Formats name, doc and type so that it can be presented in documentation
+ * @param name
+ * @param doc
+ * @param type
+ * @param checker
+ */
+function formatEntryRow(name: string, doc: JsDoc | string | undefined, type: Type | SimpleType | string | undefined, checker: TypeChecker): string {
+	const comment = typeof doc === "string" ? doc : doc?.description || "";
+	const typeText = typeof type === "string" ? type : type == null ? "" : formatType(type, checker);
+
+	return `${markdownHighlight(name)}${typeText == null ? "" : ` {${typeText}}`}${comment == null ? "" : " - "}${comment || ""}`;
+}
+
+/**
+ * Formats a type to present in documentation
+ * @param type
+ * @param checker
+ */
+function formatType(type: Type | SimpleType, checker: TypeChecker): string | undefined {
+	return !isAssignableToSimpleTypeKind(type, "ANY", checker) ? markdownHighlight(typeToString(type, checker)) : undefined;
+}

--- a/src/transformers/webtypes/webtypes-transformer.ts
+++ b/src/transformers/webtypes/webtypes-transformer.ts
@@ -111,7 +111,6 @@ function getRelativePath(fileName: string | undefined, config: TransformerConfig
 }
 
 function componentEventToAttr(event: ComponentEvent, checker: TypeChecker, config: TransformerConfig): GenericJsContribution {
-	// console.log(event);
 	const builtEvent: GenericJsContribution = {
 		name: event.name
 	};
@@ -148,6 +147,7 @@ function componentMemberToAttr(
 	const attr: HtmlAttribute = {
 		name: propName,
 		required: !!member.required,
+		priority: member.visibility == "private" || member.visibility == "protected" ? "lowest" : "normal",
 		value: {
 			type: types && Array.isArray(types) && types.length == 1 ? types[0] : types,
 			required: valueRequired,
@@ -162,7 +162,7 @@ function componentMemberToAttr(
 }
 
 function isBoolean(type: string | string[]): boolean {
-	if (Array.isArray(type)) return type.some(t => t == "boolean");
+	if (Array.isArray(type)) return type.some(t => t && t.includes("boolean"));
 
-	return type == "boolean";
+	return type ? type.includes("boolean") : false;
 }

--- a/src/transformers/webtypes/webtypes-transformer.ts
+++ b/src/transformers/webtypes/webtypes-transformer.ts
@@ -98,7 +98,7 @@ function definitionToHTMLElement(definition: ComponentDefinition, checker: TypeC
 	if (customElementProperties.length > 0) js.properties = customElementProperties;
 
 	// Build events
-	const eventAttributes = arrayDefined(declaration.events.map(e => componentEventToAttr(e, checker, config)));
+	const eventAttributes = arrayDefined(declaration.events.map(e => componentEventToAttr(e)));
 	if (eventAttributes.length > 0) js.events = eventAttributes;
 
 	if (js.properties || js.events) build.js = js;
@@ -110,7 +110,7 @@ function getRelativePath(fileName: string | undefined, config: TransformerConfig
 	return fileName != null && config.cwd != null ? `${config.pathAsAbsolute ? "" : "./"}${relative(config.cwd, fileName)}` : undefined;
 }
 
-function componentEventToAttr(event: ComponentEvent, checker: TypeChecker, config: TransformerConfig): GenericJsContribution {
+function componentEventToAttr(event: ComponentEvent): GenericJsContribution {
 	const builtEvent: GenericJsContribution = {
 		name: event.name
 	};


### PR DESCRIPTION
Add Web-Types transformer to generate web-types files.

Web-Types is a project to enable IDE auto-completion for web-components, currently implemented in IntelliJ and WebStorm: https://github.com/JetBrains/web-types

For example after generating web-types file with `web-component-analyzer`
![image](https://user-images.githubusercontent.com/24655340/150368837-1af4b9b3-d05b-45ae-810b-51952a387617.png)
