### PR TITLE
Support for TypeScript 4.8 decorator AST changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,8 @@
 				"typescript-3.5": "npm:typescript@~3.5.3",
 				"typescript-3.6": "npm:typescript@~3.6.4",
 				"typescript-3.7": "npm:typescript@~3.7.4",
-				"typescript-3.8": "npm:typescript@~3.8.0"
+				"typescript-3.8": "npm:typescript@~3.8.0",
+				"typescript-4.8": "npm:typescript@~4.8.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -5060,6 +5061,20 @@
 				"node": ">=4.2.0"
 			}
 		},
+		"node_modules/typescript-4.8": {
+			"name": "typescript",
+			"version": "4.8.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+			"integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+			"dev": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
+			}
+		},
 		"node_modules/unique-string": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
@@ -9125,6 +9140,12 @@
 			"version": "npm:typescript@3.8.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
 			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+			"dev": true
+		},
+		"typescript-4.8": {
+			"version": "npm:typescript@4.8.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+			"integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
 			"dev": true
 		},
 		"unique-string": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
 		"typescript-3.5": "npm:typescript@~3.5.3",
 		"typescript-3.6": "npm:typescript@~3.6.4",
 		"typescript-3.7": "npm:typescript@~3.7.4",
-		"typescript-3.8": "npm:typescript@~3.8.0"
+		"typescript-3.8": "npm:typescript@~3.8.0",
+		"typescript-4.8": "npm:typescript@~4.8.0"
 	},
 	"ava": {
 		"snapshotDir": "test/snapshots/results",

--- a/src/analyze/flavors/lit-element/discover-definitions.ts
+++ b/src/analyze/flavors/lit-element/discover-definitions.ts
@@ -1,6 +1,6 @@
-import { Decorator, Node, NodeArray } from "typescript";
+import { Node } from "typescript";
 import { AnalyzerVisitContext } from "../../analyzer-visit-context";
-import { getNodeIdentifier } from "../../util/ast-util";
+import { getDecorators, getNodeIdentifier } from "../../util/ast-util";
 import { resolveNodeValue } from "../../util/resolve-node-value";
 import { DefinitionNodeResult } from "../analyzer-flavor";
 
@@ -15,20 +15,8 @@ export function discoverDefinitions(node: Node, context: AnalyzerVisitContext): 
 
 	// @customElement("my-element")
 	if (ts.isClassDeclaration(node)) {
-		// As of TypeScript 4.8 decorators have been moved from the `decorators`
-		// property into `modifiers`. For compatibility with both, we manually check
-		// use both here rather than using the new `getDecorators` function.
-		//
-		// https://devblogs.microsoft.com/typescript/announcing-typescript-4-8/#decorators-are-placed-on-modifiers-on-typescripts-syntax-trees
-		const decorators = Array.from((node.decorators ?? []) as NodeArray<Decorator>);
-		for (const modifier of node.modifiers ?? []) {
-			if (ts.isDecorator(modifier)) {
-				decorators.push(modifier);
-			}
-		}
-
 		// Visit all decorators on the class
-		for (const decorator of decorators) {
+		for (const decorator of getDecorators(node, context)) {
 			const callExpression = decorator.expression;
 
 			// Find "@customElement"

--- a/src/analyze/flavors/lit-element/parse-lit-property-configuration.ts
+++ b/src/analyze/flavors/lit-element/parse-lit-property-configuration.ts
@@ -3,6 +3,7 @@ import * as tsModule from "typescript";
 import { CallExpression, Node, PropertyAssignment } from "typescript";
 import { AnalyzerVisitContext } from "../../analyzer-visit-context";
 import { LitElementPropertyConfig } from "../../types/features/lit-element-property-config";
+import { getDecorators } from "../../util/ast-util";
 import { resolveNodeValue } from "../../util/resolve-node-value";
 
 export type LitElementPropertyDecoratorKind = "property" | "internalProperty" | "state";
@@ -18,11 +19,10 @@ export function getLitElementPropertyDecorator(
 	node: Node,
 	context: AnalyzerVisitContext
 ): { expression: CallExpression; kind: LitElementPropertyDecoratorKind } | undefined {
-	if (node.decorators == null) return undefined;
 	const { ts } = context;
 
 	// Find a decorator with "property" name.
-	for (const decorator of node.decorators) {
+	for (const decorator of getDecorators(node, context)) {
 		const expression = decorator.expression;
 
 		// We find the first decorator calling specific identifier name (found in LIT_ELEMENT_PROPERTY_DECORATOR_KINDS)
@@ -34,6 +34,8 @@ export function getLitElementPropertyDecorator(
 			}
 		}
 	}
+
+	return undefined;
 }
 
 /**

--- a/src/analyze/flavors/lwc/refine-feature.ts
+++ b/src/analyze/flavors/lwc/refine-feature.ts
@@ -1,6 +1,7 @@
 import { AnalyzerVisitContext } from "../../analyzer-visit-context";
 import { ComponentFeatureBase } from "../../types/features/component-feature";
 import { ComponentMember } from "../../types/features/component-member";
+import { getDecorators } from "../../util/ast-util";
 import { Node, ClassDeclaration } from "typescript";
 
 import { ComponentMethod } from "../../types/features/component-method";
@@ -10,21 +11,25 @@ import { getLwcComponent } from "./utils";
 // In LWC, the public properties & methods must be tagged with @api
 // everything else becomes protected and not accessible externally
 function hasApiDecorator(node: Node | undefined, context: AnalyzerVisitContext) {
-	const { ts } = context;
-	if (node && node.decorators) {
-		for (const decorator of node.decorators) {
-			const expression = decorator.expression;
+	if (!node) {
+		return false;
+	}
 
-			// We find the first decorator calling specific identifier name (found in LWC_PROPERTY_DECORATOR_KINDS)
-			if (ts.isIdentifier(expression)) {
-				const identifier = expression;
-				const kind = identifier.text;
-				if (kind === "api") {
-					return true;
-				}
+	const { ts } = context;
+
+	for (const decorator of getDecorators(node, context)) {
+		const expression = decorator.expression;
+
+		// We find the first decorator calling specific identifier name (found in LWC_PROPERTY_DECORATOR_KINDS)
+		if (ts.isIdentifier(expression)) {
+			const identifier = expression;
+			const kind = identifier.text;
+			if (kind === "api") {
+				return true;
 			}
 		}
 	}
+
 	return false;
 }
 

--- a/src/analyze/flavors/lwc/utils.ts
+++ b/src/analyze/flavors/lwc/utils.ts
@@ -1,5 +1,6 @@
 import { Node, ClassDeclaration } from "typescript";
 import { AnalyzerVisitContext } from "../../analyzer-visit-context";
+import { getDecorators } from "../../util/ast-util";
 import { camelToDashCase } from "../../util/text-util";
 import { existsSync, readFileSync } from "fs";
 import { parseJsDocForNode } from "../js-doc/parse-js-doc-for-node";
@@ -127,11 +128,10 @@ function inheritFromLightning(node: ClassDeclaration, context: AnalyzerVisitCont
  * @param context
  */
 export function hasLwcApiPropertyDecorator(node: Node, context: AnalyzerVisitContext): boolean {
-	if (node.decorators == null) return false;
 	const { ts } = context;
 
 	// Find a decorator with "api" name.
-	for (const decorator of node.decorators) {
+	for (const decorator of getDecorators(node, context)) {
 		const expression = decorator.expression;
 
 		// We find the first decorator calling specific identifier name (@api)

--- a/src/analyze/util/ast-util.ts
+++ b/src/analyze/util/ast-util.ts
@@ -2,9 +2,11 @@ import { isAssignableToSimpleTypeKind } from "ts-simple-type";
 import * as tsModule from "typescript";
 import {
 	Declaration,
+	Decorator,
 	Identifier,
 	InterfaceDeclaration,
 	Node,
+	NodeArray,
 	PropertyDeclaration,
 	PropertySignature,
 	SetAccessorDeclaration,
@@ -346,4 +348,26 @@ export function getNodeIdentifier(node: Node, context: { ts: typeof tsModule }):
 	}
 
 	return undefined;
+}
+
+/**
+ * Returns all decorators in either the node's `decorators` or `modifiers`.
+ * @param node
+ * @param context
+ */
+export function getDecorators(node: Node, context: { ts: typeof tsModule }): ReadonlyArray<Decorator> {
+	const { ts } = context;
+
+	// As of TypeScript 4.8 decorators have been moved from the `decorators`
+	// property into `modifiers`. For compatibility with both, we manually check
+	// use both here rather than using the new `getDecorators` function.
+	//
+	// https://devblogs.microsoft.com/typescript/announcing-typescript-4-8/#decorators-are-placed-on-modifiers-on-typescripts-syntax-trees
+	const decorators = Array.from((node.decorators ?? []) as NodeArray<Decorator>);
+	for (const modifier of node.modifiers ?? []) {
+		if (ts.isDecorator(modifier)) {
+			decorators.push(modifier);
+		}
+	}
+	return decorators;
 }

--- a/src/analyze/util/ast-util.ts
+++ b/src/analyze/util/ast-util.ts
@@ -359,10 +359,31 @@ export function getDecorators(node: Node, context: { ts: typeof tsModule }): Rea
 	const { ts } = context;
 
 	// As of TypeScript 4.8 decorators have been moved from the `decorators`
-	// property into `modifiers`. For compatibility with both, we manually check
-	// both here rather than using the new `getDecorators` function.
+	// property into `modifiers`. For compatibility with versions on both sides of
+	// this change, this function first attempts to use the new utility functions
+	// from TS 4.8+, otherwise it combines and filters all decorators found in
+	// either `decorators` or `modifiers`.
 	//
 	// https://devblogs.microsoft.com/typescript/announcing-typescript-4-8/#decorators-are-placed-on-modifiers-on-typescripts-syntax-trees
+
+	// Declare enough of the TS 4.8 API to let us check for and use these
+	// functions despite compiling with an earlier version of TS.
+	interface HasDecorators extends Node {
+		_sentinel: never;
+	}
+	type TSModuleExports = typeof tsModule;
+	interface TS_4_8 extends TSModuleExports {
+		canHaveDecorators: (node: Node) => node is HasDecorators;
+		getDecorators: (node: HasDecorators) => ReadonlyArray<Decorator> | undefined;
+	}
+
+	// Use TS 4.8 functions if available.
+	const isTS_4_8 = (ts: typeof tsModule): ts is TS_4_8 => typeof (ts as any).canHaveDecorators === "function";
+	if (isTS_4_8(ts)) {
+		return ts.canHaveDecorators(node) ? ts.getDecorators(node) ?? [] : [];
+	}
+
+	// Fall back to manually checking `decorators` and `modifiers`.
 	const decorators = Array.from((node.decorators ?? []) as NodeArray<Decorator>);
 	for (const modifier of node.modifiers ?? []) {
 		if (ts.isDecorator(modifier)) {

--- a/src/analyze/util/ast-util.ts
+++ b/src/analyze/util/ast-util.ts
@@ -360,7 +360,7 @@ export function getDecorators(node: Node, context: { ts: typeof tsModule }): Rea
 
 	// As of TypeScript 4.8 decorators have been moved from the `decorators`
 	// property into `modifiers`. For compatibility with both, we manually check
-	// use both here rather than using the new `getDecorators` function.
+	// both here rather than using the new `getDecorators` function.
 	//
 	// https://devblogs.microsoft.com/typescript/announcing-typescript-4-8/#decorators-are-placed-on-modifiers-on-typescripts-syntax-trees
 	const decorators = Array.from((node.decorators ?? []) as NodeArray<Decorator>);

--- a/test/helpers/ts-test.ts
+++ b/test/helpers/ts-test.ts
@@ -4,11 +4,11 @@ import * as tsModule from "typescript";
 
 type TestFunction = (title: string, implementation: Implementation) => void;
 
-type TsModuleKind = "current" | "3.5" | "3.6" | "3.7" | "3.8";
+type TsModuleKind = "current" | "3.5" | "3.6" | "3.7" | "3.8" | "4.8";
 
-const TS_MODULES_ALL: TsModuleKind[] = ["current", "3.5", "3.6", "3.7", "3.8"];
+const TS_MODULES_ALL: TsModuleKind[] = ["current", "3.5", "3.6", "3.7", "3.8", "4.8"];
 
-const TS_MODULES_DEFAULT: TsModuleKind[] = ["3.5", "3.6", "3.7", "3.8"];
+const TS_MODULES_DEFAULT: TsModuleKind[] = ["3.5", "3.6", "3.7", "3.8", "4.8"];
 
 /**
  * Returns the name of the module to require for a specific ts module kind
@@ -21,6 +21,7 @@ function getTsModuleNameWithKind(kind: TsModuleKind | undefined): string {
 		case "3.6":
 		case "3.7":
 		case "3.8":
+		case "4.8":
 			return `typescript-${kind}`;
 		case "current":
 		case undefined:


### PR DESCRIPTION
This PR adds TypeScript 4.8 to the set of TypeScript versions that are tested. TypeScript 4.8 has a breaking change to the AST where the `.decorators` property has been deprecated and decorators are now found in the `.modifiers` property.[^1] This PR introduces a new `getDecorators` function that returns all decorators existing in either array, if they exist.

[^1]: https://devblogs.microsoft.com/typescript/announcing-typescript-4-8/#decorators-are-placed-on-modifiers-on-typescripts-syntax-trees