### PR TITLE
Use `isTypeAssertionExpression` instead of the deprecated `isTypeAssertion`.

### DIFF
--- a/src/analyze/util/resolve-node-value.ts
+++ b/src/analyze/util/resolve-node-value.ts
@@ -107,7 +107,7 @@ export function resolveNodeValue(node: Node | undefined, context: Context): { va
 	//  - "my-value" as string
 	//  - <any>"my-value"
 	//  - ("my-value")
-	else if (ts.isAsExpression(node) || ts.isTypeAssertion(node) || ts.isParenthesizedExpression(node)) {
+	else if (ts.isAsExpression(node) || ts.isTypeAssertionExpression(node) || ts.isParenthesizedExpression(node)) {
 		return resolveNodeValue(node.expression, { ...context, depth });
 	}
 

--- a/src/analyze/util/resolve-node-value.ts
+++ b/src/analyze/util/resolve-node-value.ts
@@ -107,7 +107,7 @@ export function resolveNodeValue(node: Node | undefined, context: Context): { va
 	//  - "my-value" as string
 	//  - <any>"my-value"
 	//  - ("my-value")
-	else if (ts.isAsExpression(node) || ts.isTypeAssertionExpression(node) || ts.isParenthesizedExpression(node)) {
+	else if (ts.isAsExpression(node) || (ts.isTypeAssertionExpression ?? ts.isTypeAssertion)(node) || ts.isParenthesizedExpression(node)) {
 		return resolveNodeValue(node.expression, { ...context, depth });
 	}
 


### PR DESCRIPTION
Upstreams <http://cl/495662713>.

`isTypeAssertionExpression` was added in microsoft/TypeScript#35282 and deprecates `isTypeAssertion`. This package supports back to at least `typescript@3.5.3`, so I've made this fall back to `isTypeAssertion` anyway.