### PR TITLE
Members' `type` functions now accept an optional descendant context declaration.

### DIFF
--- a/src/analyze/types/component-declaration.ts
+++ b/src/analyze/types/component-declaration.ts
@@ -1,4 +1,4 @@
-import { Node, SourceFile, Symbol } from "typescript";
+import { Node, SourceFile, Symbol, Type } from "typescript";
 import { ComponentCssPart } from "./features/component-css-part";
 import { ComponentCssProperty } from "./features/component-css-property";
 import { ComponentEvent } from "./features/component-event";
@@ -36,4 +36,10 @@ export interface ComponentDeclaration extends ComponentFeatures {
 	symbol?: Symbol;
 	deprecated?: boolean | string;
 	heritageClauses: ComponentHeritageClause[];
+	/**
+	 * A map from declaration nodes of this declarations's ancestors to the types
+	 * they generate in the base type tree of this component's type (i.e. with any
+	 * known type arguments resolved).
+	 */
+	ancestorDeclarationNodeToType: Map<Node, Type>;
 }

--- a/src/analyze/types/features/component-member.ts
+++ b/src/analyze/types/features/component-member.ts
@@ -3,6 +3,7 @@ import { Node, Type } from "typescript";
 import { PriorityKind } from "../../flavors/analyzer-flavor";
 import { ModifierKind } from "../modifier-kind";
 import { VisibilityKind } from "../visibility-kind";
+import { ComponentDeclaration } from "../component-declaration";
 import { ComponentFeatureBase } from "./component-feature";
 import { LitElementPropertyConfig } from "./lit-element-property-config";
 
@@ -16,7 +17,12 @@ export interface ComponentMemberBase extends ComponentFeatureBase {
 	priority?: PriorityKind;
 
 	typeHint?: string;
-	type: undefined | (() => Type | SimpleType);
+	/**
+	 * @param {ComponentDeclaration} descendant - The component declaration for
+	 * which this member's type is being retrieved, which may vary if there are
+	 * generic types in that component's inheritance chain.
+	 */
+	type: undefined | ((descendant?: ComponentDeclaration) => Type | SimpleType);
 
 	meta?: LitElementPropertyConfig;
 


### PR DESCRIPTION
Component members are discovered within the context of some declaration associated with a single AST node. If that declaration has free type parameters, then asking the type checker for that declaration's AST node's type will return a type that still contains those free type parameters. Further, different choices for those type parameters in descendant component declarations may cause the type of the member to vary.

To allow a member to return its type with all type arguments substituted, members' `type` functions can now optionally be passed a component declaration that (inclusively) descends from the member's declaration. The type returned will be the type of this member *for an instance of the given declaration*.