### PR TITLE
fix: use isTypeAssertionExpression since old method is deprecated

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,11 +38,10 @@
 				"rollup-plugin-copy": "^3.4.0",
 				"ts-node": "^10.0.0",
 				"tslib": "^2.2.0",
-				"typescript-3.5": "npm:typescript@~3.5.3",
-				"typescript-3.6": "npm:typescript@~3.6.4",
-				"typescript-3.7": "npm:typescript@~3.7.4",
-				"typescript-3.8": "npm:typescript@~3.8.0",
-				"typescript-4.8": "npm:typescript@~4.8.0"
+				"typescript-4.0": "npm:typescript@~4.0.0",
+				"typescript-4.5": "npm:typescript@~4.5.0",
+				"typescript-4.8": "npm:typescript@~4.8.0",
+				"typescript-5.0": "npm:typescript@~5.0.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -5005,11 +5004,11 @@
 				"node": ">=4.2.0"
 			}
 		},
-		"node_modules/typescript-3.5": {
+		"node_modules/typescript-4.0": {
 			"name": "typescript",
-			"version": "3.5.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-			"integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.8.tgz",
+			"integrity": "sha512-oz1765PN+imfz1MlZzSZPtC/tqcwsCyIYA8L47EkRnRW97ztRk83SzMiWLrnChC0vqoYxSU1fcFUDA5gV/ZiPg==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -5019,39 +5018,11 @@
 				"node": ">=4.2.0"
 			}
 		},
-		"node_modules/typescript-3.6": {
+		"node_modules/typescript-4.5": {
 			"name": "typescript",
-			"version": "3.6.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.5.tgz",
-			"integrity": "sha512-BEjlc0Z06ORZKbtcxGrIvvwYs5hAnuo6TKdNFL55frVDlB+na3z5bsLhFaIxmT+dPWgBIjMo6aNnTOgHHmHgiQ==",
-			"dev": true,
-			"bin": {
-				"tsc": "bin/tsc",
-				"tsserver": "bin/tsserver"
-			},
-			"engines": {
-				"node": ">=4.2.0"
-			}
-		},
-		"node_modules/typescript-3.7": {
-			"name": "typescript",
-			"version": "3.7.7",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.7.tgz",
-			"integrity": "sha512-MmQdgo/XenfZPvVLtKZOq9jQQvzaUAUpcKW8Z43x9B2fOm4S5g//tPtMweZUIP+SoBqrVPEIm+dJeQ9dfO0QdA==",
-			"dev": true,
-			"bin": {
-				"tsc": "bin/tsc",
-				"tsserver": "bin/tsserver"
-			},
-			"engines": {
-				"node": ">=4.2.0"
-			}
-		},
-		"node_modules/typescript-3.8": {
-			"name": "typescript",
-			"version": "3.8.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+			"version": "4.5.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+			"integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -5073,6 +5044,20 @@
 			},
 			"engines": {
 				"node": ">=4.2.0"
+			}
+		},
+		"node_modules/typescript-5.0": {
+			"name": "typescript",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+			"integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+			"dev": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=12.20"
 			}
 		},
 		"node_modules/unique-string": {
@@ -9118,34 +9103,28 @@
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
 			"integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA=="
 		},
-		"typescript-3.5": {
-			"version": "npm:typescript@3.5.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-			"integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+		"typescript-4.0": {
+			"version": "npm:typescript@4.0.8",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.8.tgz",
+			"integrity": "sha512-oz1765PN+imfz1MlZzSZPtC/tqcwsCyIYA8L47EkRnRW97ztRk83SzMiWLrnChC0vqoYxSU1fcFUDA5gV/ZiPg==",
 			"dev": true
 		},
-		"typescript-3.6": {
-			"version": "npm:typescript@3.6.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.5.tgz",
-			"integrity": "sha512-BEjlc0Z06ORZKbtcxGrIvvwYs5hAnuo6TKdNFL55frVDlB+na3z5bsLhFaIxmT+dPWgBIjMo6aNnTOgHHmHgiQ==",
-			"dev": true
-		},
-		"typescript-3.7": {
-			"version": "npm:typescript@3.7.7",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.7.tgz",
-			"integrity": "sha512-MmQdgo/XenfZPvVLtKZOq9jQQvzaUAUpcKW8Z43x9B2fOm4S5g//tPtMweZUIP+SoBqrVPEIm+dJeQ9dfO0QdA==",
-			"dev": true
-		},
-		"typescript-3.8": {
-			"version": "npm:typescript@3.8.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+		"typescript-4.5": {
+			"version": "npm:typescript@4.5.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+			"integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
 			"dev": true
 		},
 		"typescript-4.8": {
 			"version": "npm:typescript@4.8.4",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
 			"integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+			"dev": true
+		},
+		"typescript-5.0": {
+			"version": "npm:typescript@5.0.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+			"integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
 			"dev": true
 		},
 		"unique-string": {

--- a/package.json
+++ b/package.json
@@ -75,11 +75,10 @@
 		"rollup-plugin-copy": "^3.4.0",
 		"ts-node": "^10.0.0",
 		"tslib": "^2.2.0",
-		"typescript-3.5": "npm:typescript@~3.5.3",
-		"typescript-3.6": "npm:typescript@~3.6.4",
-		"typescript-3.7": "npm:typescript@~3.7.4",
-		"typescript-3.8": "npm:typescript@~3.8.0",
-		"typescript-4.8": "npm:typescript@~4.8.0"
+		"typescript-4.0": "npm:typescript@~4.0.0",
+		"typescript-4.5": "npm:typescript@~4.5.0",
+		"typescript-4.8": "npm:typescript@~4.8.0",
+		"typescript-5.0": "npm:typescript@~5.0.0"
 	},
 	"ava": {
 		"snapshotDir": "test/snapshots/results",

--- a/src/analyze/util/resolve-node-value.ts
+++ b/src/analyze/util/resolve-node-value.ts
@@ -107,7 +107,7 @@ export function resolveNodeValue(node: Node | undefined, context: Context): { va
 	//  - "my-value" as string
 	//  - <any>"my-value"
 	//  - ("my-value")
-	else if (ts.isAsExpression(node) || ts.isTypeAssertion(node) || ts.isParenthesizedExpression(node)) {
+	else if (ts.isAsExpression(node) || ts.isTypeAssertionExpression(node) || ts.isParenthesizedExpression(node)) {
 		return resolveNodeValue(node.expression, { ...context, depth });
 	}
 

--- a/test/flavors/custom-element/analyze-html-element-test.ts
+++ b/test/flavors/custom-element/analyze-html-element-test.ts
@@ -14,9 +14,12 @@ tsTest("analyzeHTMLElement returns correct result", t => {
 	const ext = getAllInheritedNames(result!.heritageClauses);
 
 	// Test that the node extends some of the interfaces
+	if (!tsModule.version.startsWith("5.")) {
+		t.truthy(ext.has("DocumentAndElementEventHandlers"));
+	}
+	t.truthy(ext.has("GlobalEventHandlers"));
 	t.truthy(ext.has("EventTarget"));
 	t.truthy(ext.has("Node"));
-	t.truthy(ext.has("DocumentAndElementEventHandlers"));
 	t.truthy(ext.has("ElementContentEditable"));
 
 	// From ElementContentEditable interface

--- a/test/helpers/ts-test.ts
+++ b/test/helpers/ts-test.ts
@@ -4,11 +4,11 @@ import * as tsModule from "typescript";
 
 type TestFunction = (title: string, implementation: Implementation) => void;
 
-type TsModuleKind = "current" | "3.5" | "3.6" | "3.7" | "3.8" | "4.8";
+type TsModuleKind = "current" | "4.0" | "4.5" | "4.8" | "5.0";
 
-const TS_MODULES_ALL: TsModuleKind[] = ["current", "3.5", "3.6", "3.7", "3.8", "4.8"];
+const TS_MODULES_ALL: TsModuleKind[] = ["current", "4.0", "4.5", "4.8", "5.0"];
 
-const TS_MODULES_DEFAULT: TsModuleKind[] = ["3.5", "3.6", "3.7", "3.8", "4.8"];
+const TS_MODULES_DEFAULT: TsModuleKind[] = ["4.0", "4.5", "4.8", "5.0"];
 
 /**
  * Returns the name of the module to require for a specific ts module kind
@@ -17,11 +17,10 @@ const TS_MODULES_DEFAULT: TsModuleKind[] = ["3.5", "3.6", "3.7", "3.8", "4.8"];
 function getTsModuleNameWithKind(kind: TsModuleKind | undefined): string {
 	// Return the corresponding ts module
 	switch (kind) {
-		case "3.5":
-		case "3.6":
-		case "3.7":
-		case "3.8":
+		case "4.0":
+		case "4.5":
 		case "4.8":
+		case "5.0":
 			return `typescript-${kind}`;
 		case "current":
 		case undefined:


### PR DESCRIPTION
super tiny change but this is mostly why lit-analyzer falls over right now

cc @rictic if you can get someone to review this and publish a new version, assuming its fine, that'd be great