### PR TITLE
feat: support tag names which are static class properties

### DIFF
--- a/src/analyze/util/ast-util.ts
+++ b/src/analyze/util/ast-util.ts
@@ -197,12 +197,16 @@ export function getInterfaceKeys(
 			if (resolvedKey == null) {
 				continue;
 			}
-
+			let keyNode = resolvedKey.node;
 			let identifier: Node | undefined;
 			let declaration: Node | undefined;
 			if (ts.isTypeReferenceNode(member.type)) {
 				// { ____: MyButton; } or { ____: namespace.MyButton; }
 				identifier = member.type.typeName;
+				if (ts.isComputedPropertyName(member.name)) {
+					// e.g. [MyButton.TAG] : MyButton -> use initial member name node instead of resolved node
+					keyNode = member.name.expression;
+				}
 			} else if (ts.isTypeLiteralNode(member.type)) {
 				identifier = undefined;
 				declaration = member.type;
@@ -211,7 +215,7 @@ export function getInterfaceKeys(
 			}
 
 			if (declaration != null || identifier != null) {
-				extensions.push({ key: String(resolvedKey.value), keyNode: resolvedKey.node, declaration, identifier });
+				extensions.push({ key: String(resolvedKey.value), keyNode: keyNode, declaration, identifier });
 			}
 		}
 	}

--- a/src/analyze/util/resolve-node-value.ts
+++ b/src/analyze/util/resolve-node-value.ts
@@ -77,12 +77,14 @@ export function resolveNodeValue(node: Node | undefined, context: Context): { va
 		return resolveNodeValue(node.expression, { ...context, depth });
 	}
 
-	// Resolve initializer value of enum members.
-	else if (ts.isEnumMember(node)) {
+	// Resolve initializer value of enum members or class properties.
+	else if (ts.isEnumMember(node) || ts.isPropertyDeclaration(node)) {
 		if (node.initializer != null) {
 			return resolveNodeValue(node.initializer, { ...context, depth });
-		} else {
+		} else if (node.parent.name) {
 			return { value: `${node.parent.name.text}.${node.name.getText()}`, node };
+		} else {
+			return { value: `${node.name.getText()}`, node };
 		}
 	}
 


### PR DESCRIPTION
* Tag name is correctly resolved if tag name is a static class property
* When "discovering" custom element definitions in `HTMLElementTagNameMap`, where the tag name is a static class property, the node holding the property is resolved. As such lit-analyzer _no-missing-element-type-definition_ rule behaves correctly

Resolves #278